### PR TITLE
Fix blacksmith building template reference

### DIFF
--- a/assets/prefabs/buildings/Blacksmith.prefab
+++ b/assets/prefabs/buildings/Blacksmith.prefab
@@ -1,7 +1,7 @@
 {
     "GenericBuilding" : {
      "name" : "blacksmith",
-     "templateNames" : ["TutorialDynamicCity:smithyTemplate"],
+     "templateNames" : ["MetalRenegades:smithyTemplate"],
      "zone" : "COMMERCIAL",
      "minSize" : [14, 14],
      "maxSize" : [17, 17],


### PR DESCRIPTION
The blacksmith building file `Blacksmith.prefab` used the `smithyTemplate` file from TutorialDynamicCity. This module is not a dependancy, so this results in blank spaces in cities if this module is not manually activated.

Fixed by changing this reference to `MetalRenegades:smithyTemplate`