### PR TITLE
Slight spawning performance tweaks

### DIFF
--- a/assets/prefabs/buildings/Blacksmith.prefab
+++ b/assets/prefabs/buildings/Blacksmith.prefab
@@ -12,9 +12,6 @@
      "productionInterval" : 500,
      "consumption" : {"Core:plank" : 16},
      "consumptionInterval" : 100
-    },
-    "PotentialHome": {
-        "maxResidents": 1
     }
 }
 

--- a/assets/prefabs/buildings/marketPlace.prefab
+++ b/assets/prefabs/buildings/marketPlace.prefab
@@ -13,9 +13,6 @@
     },
     "InfiniteStorage" : {
      "inventory" : {}
-    },
-    "PotentialHome": {
-        "maxResidents": 1
     }
 }
 

--- a/assets/prefabs/buildings/simpleChurch.prefab
+++ b/assets/prefabs/buildings/simpleChurch.prefab
@@ -6,9 +6,6 @@
      "minSize" : [20, 20],
      "maxSize" : [30, 30],
         "isEntity" : true
-    },
-    "PotentialHome": {
-        "maxResidents": 5
     }
 }
 

--- a/assets/prefabs/buildings/townHall.prefab
+++ b/assets/prefabs/buildings/townHall.prefab
@@ -6,9 +6,6 @@
      "minSize" : [25, 25],
      "maxSize" : [30, 30],
         "isEntity" : true
-    },
-    "PotentialHome": {
-        "maxResidents": 3
     }
 }
 

--- a/src/main/java/org/terasology/metalrenegades/ai/system/ResidentSpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/ResidentSpawnSystem.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 @RegisterSystem(value = RegisterMode.AUTHORITY)
 public class ResidentSpawnSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 
-    private static final int SPAWN_CHECK_DELAY = 30;
+    private static final int SPAWN_CHECK_DELAY = 90;
 
     private float spawnTimer;
 


### PR DESCRIPTION
## Contains
- Adjustment to character spawn check to only activate every 90 seconds instead of 30 seconds
- Disable characters spawning inside non-residential buildings, greatly reducing the number of characters spawning inside cities (there were five characters spawned inside a small church building!)