### PR TITLE
Add AdvancedRails to dependencies

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -9,7 +9,8 @@
         {"id" : "OreGeneration", "minVersion" : "1.0.0"},
         {"id" : "DynamicCities", "minVersion" : "0.2.1"},
         {"id" : "Behaviors", "minVersion" : "0.2.0"},
-        {"id" : "Rails", "minVersion" : "0.4.0"}
+        {"id" : "Rails", "minVersion" : "0.4.0"},
+        {"id" : "AdvancedRails", "minVersion" : "0.1.0"}
     ],
     "serverSideOnly" : false
 }


### PR DESCRIPTION
Just adds the module as a dependency.

**To Test:**
 - Use `give locoItem` to get the locomotive vehicle from the AdvancedRails module.