### PR TITLE
Set blacksmith template size to a fixed value

### DIFF
--- a/assets/prefabs/buildings/Blacksmith.prefab
+++ b/assets/prefabs/buildings/Blacksmith.prefab
@@ -3,8 +3,8 @@
      "name" : "blacksmith",
      "templateNames" : ["MetalRenegades:smithyTemplate"],
      "zone" : "COMMERCIAL",
-     "minSize" : [14, 14],
-     "maxSize" : [17, 17],
+     "minSize" : [15, 15],
+     "maxSize" : [15, 15],
      "isEntity" : true
     },
     "MarketSubscriber" : {


### PR DESCRIPTION
## Contains

An adjustment to the blacksmith building size to be a fixed value, with both sides the same length. This makes structure template placement look more stable when using Terasology/DynamicCities#49.