### PR TITLE
Settlementgrowth Cycles changed from within MetalRenegades

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/SettlementGrowthSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SettlementGrowthSystem.java
@@ -15,14 +15,11 @@
  */
 package org.terasology.metalrenegades.world;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.terasology.dynamicCities.settlements.SettlementEntityManager;
-import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.network.NetworkSystem;
 import org.terasology.registry.In;
 
 

--- a/src/main/java/org/terasology/metalrenegades/world/SettlementGrowthSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SettlementGrowthSystem.java
@@ -29,11 +29,11 @@ public class SettlementGrowthSystem extends BaseComponentSystem {
     @In
     private SettlementEntityManager settlementEntityManager;
 
-    private int CYCLES = 2;
+    private int Cycles = 2;
 
     @Override
     public void postBegin() {
-       settlementEntityManager.setCityCyclesBeforeGrowth(CYCLES);
+       settlementEntityManager.setCityCyclesBeforeGrowth(Cycles);
     }
 
 

--- a/src/main/java/org/terasology/metalrenegades/world/SettlementGrowthSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SettlementGrowthSystem.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.metalrenegades.world;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.dynamicCities.settlements.SettlementEntityManager;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.network.NetworkSystem;
+import org.terasology.registry.In;
+
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class SettlementGrowthSystem extends BaseComponentSystem {
+
+    @In
+    private SettlementEntityManager settlementEntityManager;
+
+    private int CYCLES = 2;
+
+    @Override
+    public void postBegin() {
+       settlementEntityManager.setCityCyclesBeforeGrowth(CYCLES);
+    }
+
+
+}


### PR DESCRIPTION
Fixes #41. Related to https://github.com/Terasology/DynamicCities/pull/58
The city growth rate can be changed in MetalRenegades SettlementGrowthSystem.
Just change the number of CYCLES 
-to a high value (leads to slow growth)
-to 1 (leads to very quick growth)