### PR TITLE
feat: Use StartingInventorySystem via prefab delta

### DIFF
--- a/deltas/engine/prefabs/player.prefab
+++ b/deltas/engine/prefabs/player.prefab
@@ -1,0 +1,14 @@
+{
+  "StartingInventory": {
+    "items": [
+      { "uri": "MetalRenegades:pistol", "quantity": 1 },
+      { "uri": "MetalRenegades:bulletItem", "quantity": 32 },
+      { "uri": "core:pickaxe", "quantity": 1 },
+      { "uri": "core:shovel", "quantity": 1 },
+      { "uri": "core:axe", "quantity": 1 },
+      { "uri": "core:explodeTool", "quantity": 1 },
+      { "uri": "core:railgunTool", "quantity": 1 },
+      { "uri": "CoreBlocks:Torch", "quantity": 99 }
+    ]
+  }
+}

--- a/src/main/java/org/terasology/metalrenegades/PlayerInventorySystem.java
+++ b/src/main/java/org/terasology/metalrenegades/PlayerInventorySystem.java
@@ -58,11 +58,6 @@ public class PlayerInventorySystem extends BaseComponentSystem {
     @In
     private LocalPlayer localPlayer;
 
-    /**
-     * Number of bullets and torches to be given to players at spawn
-     */
-    private final int NUM_BULLET = 32;
-    private final int NUM_TORCH = 99;
 
     /**
      * Parameters for item drop position
@@ -72,19 +67,9 @@ public class PlayerInventorySystem extends BaseComponentSystem {
 
     @Override
     public void postBegin() {
+        // Ensure that CombatSystem does not spawn its own starting inventory.
         Map<String, Integer> items = new HashMap<>();
         Map<String, Integer> blocks = new HashMap<>();
-
-        items.put("MetalRenegades:pistol", 1);
-        items.put("MetalRenegades:bulletItem", NUM_BULLET);
-        items.put("core:pickaxe", 1);
-        items.put("core:shovel", 1);
-        items.put("core:axe", 1);
-        items.put("core:explodeTool", 1);
-        items.put("core:railgunTool", 1);
-
-        blocks.put("CoreBlocks:Torch", NUM_TORCH);
-
         combatStartingInventory.setItems(items, blocks);
     }
 


### PR DESCRIPTION
Switch ```MetalRenegades``` to using ```StartingInventorySystem```.

**How To Test**

Load a game with ```MetalRenegades``` as the gameplay module and verify that the starting inventory is the same (may be in a different order).