### PR TITLE
feat: Reduce city growth rate, and tune building ratios

### DIFF
--- a/assets/prefabs/cultures/default.prefab
+++ b/assets/prefabs/cultures/default.prefab
@@ -1,8 +1,8 @@
 {
     "Culture" : {
         "name" : "develop clan",
-        "buildingNeedPerZone" : {"UTILITY" : 2, "GOVERNMENTAL" : 1, "CLERICAL" : 1, "RESIDENTIAL" : 12, "COMMERCIAL" : 6},
-        "growthRate" : 500,
+        "buildingNeedPerZone" : {"UTILITY" : 0.08, "GOVERNMENTAL" : 0.5, "CLERICAL" : 0.5, "RESIDENTIAL" : 1.1, "COMMERCIAL" : 0.7},
+        "growthRate" : 8,
         "availableBuildings" : ["Marketplace", "House", "SimpleChurch", "blacksmith", "Townhall", "Well"],
         "residentialZones" : ["RESIDENTIAL"]
     }


### PR DESCRIPTION
**Requires [Terasology/DynamicCities#63](https://github.com/Terasology/DynamicCities/pull/63) to work!**

Greatly reduces the growth rate of MR cities, by almost 60x. This is done by modifying the culture growth rate. This number sets the growth rate of a cities "population", which is in turn used to determine when buildings should be placed. A value of 8 changes city growth to be much slower, but still noticable.

As well, the ratios of each building type have been modified to be more friendly for gameplay & the game world. Building need is calculated according to the area of placed buildings, where a larger building has more influence on the generation system than a smaller building. Therefore, smaller buildings such as wells must be tuned down to compensate for this. In general, all building need values have been greatly reduced in order to reduce the growth rate further.