### PR TITLE
Lower character/deer spawns by half

### DIFF
--- a/assets/prefabs/buildings/residentialHouse.prefab
+++ b/assets/prefabs/buildings/residentialHouse.prefab
@@ -8,7 +8,7 @@
         "isEntity" : true
     },
     "PotentialHome": {
-        "maxCitizens": 2
+        "maxCitizens": 1
     },
     "SimpleSource": {
         "needType": "REST"

--- a/src/main/java/org/terasology/metalrenegades/combat/AnimalSpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/combat/AnimalSpawnSystem.java
@@ -50,7 +50,7 @@ public class AnimalSpawnSystem extends BaseComponentSystem {
         spawnSystem.setSpawnCondition(this::isValidSpawnPosition);
 
         AnimalSpawnConfig configuration = new AnimalSpawnConfig();
-        configuration.SPAWN_CHANCE_IN_PERCENT = 2;
+        configuration.SPAWN_CHANCE_IN_PERCENT = 1;
         configuration.MAX_DEER_GROUP_SIZE = 5;
         configuration.MIN_DEER_GROUP_SIZE = 2;
         configuration.MIN_GROUND_PER_DEER = 10;


### PR DESCRIPTION
Improves in-game performance by lowering the number of in-game characters and deer by half. Residential houses now only hold one citizen each, and deer spawn chance is lowered from 2% to 1%. Improves in-game performance by lowering the demand on `SkeletonRenderer`.