### PR TITLE
Citizen Death System

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/ai/event/CitizenDeathEvent.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/event/CitizenDeathEvent.java
@@ -5,5 +5,8 @@ package org.terasology.metalrenegades.ai.event;
 
 import org.terasology.entitySystem.event.Event;
 
+/**
+ * Fired whenever an entity with a citizen component dies
+ */
 public class CitizenDeathEvent implements Event {
 }

--- a/src/main/java/org/terasology/metalrenegades/ai/event/CitizenDeathEvent.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/event/CitizenDeathEvent.java
@@ -1,0 +1,9 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.ai.event;
+
+import org.terasology.entitySystem.event.Event;
+
+public class CitizenDeathEvent implements Event {
+}

--- a/src/main/java/org/terasology/metalrenegades/ai/system/CitizenDeathSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/CitizenDeathSystem.java
@@ -5,25 +5,16 @@ package org.terasology.metalrenegades.ai.system;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.logic.characters.AliveCharacterComponent;
-import org.terasology.logic.characters.CharacterComponent;
-import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.health.BeforeDestroyEvent;
-import org.terasology.logic.health.DestroyEvent;
-import org.terasology.logic.health.HealthComponent;
-import org.terasology.logic.health.event.RestoreFullHealthEvent;
-import org.terasology.logic.players.PlayerCharacterComponent;
+import org.terasology.metalrenegades.ai.component.CitizenComponent;
 import org.terasology.metalrenegades.ai.event.CitizenDeathEvent;
 import org.terasology.metalrenegades.minimap.events.RemoveCharacterFromOverlayEvent;
-import org.terasology.registry.In;
-import org.terasology.world.time.WorldTimeEvent;
 
 /**
  * System to handle Citizen Deaths within Metal Renegades
@@ -36,14 +27,18 @@ public class CitizenDeathSystem extends BaseComponentSystem {
 
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
-    public void onCitizenDeath(BeforeDestroyEvent event, EntityRef entityRef,
-                               AliveCharacterComponent aliveCharacterComponent) {
-        entityRef.send(new RemoveCharacterFromOverlayEvent());
+    public void onEntityDestroyed(BeforeDestroyEvent event, EntityRef entityRef,
+                                  CitizenComponent citizenComponent) {
+        entityRef.send(new CitizenDeathEvent());
+        event.consume();
+    }
 
+    @ReceiveEvent
+    public void onCitizenDeath(CitizenDeathEvent event, EntityRef entityRef) {
+        entityRef.send(new RemoveCharacterFromOverlayEvent());
         logger.info("{} has died ", entityRef.toString());
         entityRef.destroy();
 
-        event.consume();
     }
 
 }

--- a/src/main/java/org/terasology/metalrenegades/ai/system/CitizenDeathSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/CitizenDeathSystem.java
@@ -7,43 +7,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.characters.AliveCharacterComponent;
+import org.terasology.logic.characters.CharacterComponent;
+import org.terasology.logic.characters.CharacterTeleportEvent;
+import org.terasology.logic.health.BeforeDestroyEvent;
+import org.terasology.logic.health.DestroyEvent;
 import org.terasology.logic.health.HealthComponent;
+import org.terasology.logic.health.event.RestoreFullHealthEvent;
+import org.terasology.logic.players.PlayerCharacterComponent;
 import org.terasology.metalrenegades.ai.event.CitizenDeathEvent;
 import org.terasology.metalrenegades.minimap.events.RemoveCharacterFromOverlayEvent;
 import org.terasology.registry.In;
 import org.terasology.world.time.WorldTimeEvent;
+
+/**
+ * System to handle Citizen Deaths within Metal Renegades
+ */
 
 @RegisterSystem(value = RegisterMode.AUTHORITY)
 public class CitizenDeathSystem extends BaseComponentSystem {
 
     Logger logger = LoggerFactory.getLogger(CitizenDeathSystem.class);
 
-    @In
-    EntityManager entityManager;
 
-    @ReceiveEvent
-    public void onWorldTimeEvent(WorldTimeEvent event, EntityRef entityRef){
-        for(EntityRef entity : entityManager.getEntitiesWith(HealthComponent.class)){
-            if(entity.getComponent(HealthComponent.class).currentHealth<=0){
+    @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
+    public void onCitizenDeath(BeforeDestroyEvent event, EntityRef entityRef,
+                               AliveCharacterComponent aliveCharacterComponent) {
+        entityRef.send(new RemoveCharacterFromOverlayEvent());
 
-                entity.send(new CitizenDeathEvent());
+        logger.info("{} has died ", entityRef.toString());
+        entityRef.destroy();
 
-
-
-            }
-        }
-    }
-
-    @ReceiveEvent
-    public void onCitizenDeath(CitizenDeathEvent event, EntityRef entity){
-        logger.error("Remove character overlay has been called");
-        entity.send(new RemoveCharacterFromOverlayEvent());
-        logger.debug("Entity is destroyed  {}", entity.toFullDescription());
-        //entity.destroy();
+        event.consume();
     }
 
 }

--- a/src/main/java/org/terasology/metalrenegades/ai/system/CitizenDeathSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/CitizenDeathSystem.java
@@ -1,0 +1,49 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.ai.system;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.health.HealthComponent;
+import org.terasology.metalrenegades.ai.event.CitizenDeathEvent;
+import org.terasology.metalrenegades.minimap.events.RemoveCharacterFromOverlayEvent;
+import org.terasology.registry.In;
+import org.terasology.world.time.WorldTimeEvent;
+
+@RegisterSystem(value = RegisterMode.AUTHORITY)
+public class CitizenDeathSystem extends BaseComponentSystem {
+
+    Logger logger = LoggerFactory.getLogger(CitizenDeathSystem.class);
+
+    @In
+    EntityManager entityManager;
+
+    @ReceiveEvent
+    public void onWorldTimeEvent(WorldTimeEvent event, EntityRef entityRef){
+        for(EntityRef entity : entityManager.getEntitiesWith(HealthComponent.class)){
+            if(entity.getComponent(HealthComponent.class).currentHealth<=0){
+
+                entity.send(new CitizenDeathEvent());
+
+
+
+            }
+        }
+    }
+
+    @ReceiveEvent
+    public void onCitizenDeath(CitizenDeathEvent event, EntityRef entity){
+        logger.error("Remove character overlay has been called");
+        entity.send(new RemoveCharacterFromOverlayEvent());
+        logger.debug("Entity is destroyed  {}", entity.toFullDescription());
+        //entity.destroy();
+    }
+
+}

--- a/src/main/java/org/terasology/metalrenegades/minimap/AddCharacterPositionOverlaySystem.java
+++ b/src/main/java/org/terasology/metalrenegades/minimap/AddCharacterPositionOverlaySystem.java
@@ -16,6 +16,8 @@
 package org.terasology.metalrenegades.minimap;
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -34,6 +36,8 @@ import org.terasology.registry.In;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class AddCharacterPositionOverlaySystem extends BaseComponentSystem {
+
+    Logger logger = LoggerFactory.getLogger(AddCharacterPositionOverlaySystem.class);
 
     @In
     private MinimapSystem minimapSystem;
@@ -72,6 +76,7 @@ public class AddCharacterPositionOverlaySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void onRemoveCharacterOverlayFromEvent(RemoveCharacterFromOverlayEvent event, EntityRef entityRef) {
         characterOverlay.removeCitizen(entityRef);
+
     }
 
     /**

--- a/src/main/java/org/terasology/metalrenegades/minimap/AddCharacterPositionOverlaySystem.java
+++ b/src/main/java/org/terasology/metalrenegades/minimap/AddCharacterPositionOverlaySystem.java
@@ -75,6 +75,7 @@ public class AddCharacterPositionOverlaySystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onRemoveCharacterOverlayFromEvent(RemoveCharacterFromOverlayEvent event, EntityRef entityRef) {
+        logger.info("{} has been removed from the minimap ", entityRef.toString());
         characterOverlay.removeCitizen(entityRef);
 
     }


### PR DESCRIPTION
# Citizen Death System to Handle all Metal Renegades features

## Motive and Explanation 

With recent fixes in the Health logic, Metal Renegades citizens were finally dying. However, I noticed a bunch of MR specific features was not being dealt with properly. For example, the Minimap was continually throwing an error, stating "No Citizen found" because, even though the entity had been destroyed, it had not been removed from the minimap. 
When more features are added into the game such as maybe a Citizen Death type task, it would really help to have such a System to deal with such cases effectively.

## Testing Instructions
Fire up Metal Renegades and destroy a citizen until the health reaches 0. The citizen should die instantly. And if you check the logs, you will not find any warning or error.