### PR TITLE
Fix market operations to work on multiplayer mode

### DIFF
--- a/assets/prefabs/buildings/marketPlace.prefab
+++ b/assets/prefabs/buildings/marketPlace.prefab
@@ -9,12 +9,11 @@
     },
     "MarketSubscriber" : {
      "production" : {
-       "waffles" : 10,
-       "Blueberry": 1,
-       "Raspberry": 1,
-       "Strawberry": 1
+       "AdditionalFruits:Blueberry": 3,
+       "AdditionalFruits:Raspberry": 3,
+       "AdditionalFruits:Strawberry": 3
      },
-     "productionInterval" : 100
+    "productionInterval" : 10000
     },
     "InfiniteStorage" : {
      "inventory" : {}

--- a/src/main/java/org/terasology/metalrenegades/economy/actions/ShowMarketScreenAction.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/actions/ShowMarketScreenAction.java
@@ -17,6 +17,8 @@
 package org.terasology.metalrenegades.economy.actions;
 
 import org.terasology.dialogs.action.PlayerAction;
+import org.terasology.dynamicCities.buildings.components.SettlementRefComponent;
+import org.terasology.dynamicCities.settlements.components.MarketComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.metalrenegades.economy.events.MarketScreenRequestEvent;
 import org.terasology.metalrenegades.economy.events.TransactionType;
@@ -45,8 +47,5 @@ public class ShowMarketScreenAction implements PlayerAction {
         talkTo.send(new MarketScreenRequestEvent(marketID, charEntity, type));
     }
 
-    public long getMarketID() {
-        return marketID;
-    }
 }
 

--- a/src/main/java/org/terasology/metalrenegades/economy/actions/ShowMarketScreenAction.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/actions/ShowMarketScreenAction.java
@@ -17,8 +17,6 @@
 package org.terasology.metalrenegades.economy.actions;
 
 import org.terasology.dialogs.action.PlayerAction;
-import org.terasology.dynamicCities.buildings.components.SettlementRefComponent;
-import org.terasology.dynamicCities.settlements.components.MarketComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.metalrenegades.economy.events.MarketScreenRequestEvent;
 import org.terasology.metalrenegades.economy.events.TransactionType;

--- a/src/main/java/org/terasology/metalrenegades/economy/events/MarketTransactionRequest.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/events/MarketTransactionRequest.java
@@ -1,0 +1,32 @@
+package org.terasology.metalrenegades.economy.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.metalrenegades.economy.ui.MarketItem;
+import org.terasology.network.ServerEvent;
+
+/**
+ * A client-to-server event which requests the transaction of a particular item.
+ */
+@ServerEvent
+public class MarketTransactionRequest implements Event {
+
+    /**
+     * The item to be bought/sold.
+     */
+    public MarketItem item;
+
+    /**
+     * The type of transaction to take place.
+     */
+    public TransactionType type;
+
+    public MarketTransactionRequest(MarketItem item, TransactionType type) {
+        this.item = item;
+        this.type = type;
+    }
+
+    public MarketTransactionRequest() {
+
+    }
+
+}

--- a/src/main/java/org/terasology/metalrenegades/economy/events/UpdateMarketScreenEvent.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/events/UpdateMarketScreenEvent.java
@@ -1,0 +1,9 @@
+package org.terasology.metalrenegades.economy.events;
+
+import org.terasology.entitySystem.event.Event;
+
+public class UpdateMarketScreenEvent implements Event {
+
+    public UpdateMarketScreenEvent() { }
+
+}

--- a/src/main/java/org/terasology/metalrenegades/economy/systems/MarketCitizenSpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/systems/MarketCitizenSpawnSystem.java
@@ -32,6 +32,7 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector3f;
@@ -47,7 +48,7 @@ import java.util.Optional;
 /**
  * Spawns a market citizen in all markets
  */
-@RegisterSystem
+@RegisterSystem(RegisterMode.AUTHORITY)
 public class MarketCitizenSpawnSystem extends BaseComponentSystem {
 
     @In
@@ -71,7 +72,6 @@ public class MarketCitizenSpawnSystem extends BaseComponentSystem {
                 trader.addComponent(settlementRefComponent);
                 MarketComponent marketComponent = settlementRefComponent.settlement.getComponent(MarketComponent.class);
 
-
                 DialogComponent dialogComponent = new DialogComponent();
                 dialogComponent.pages = new ArrayList<>();
 
@@ -81,12 +81,12 @@ public class MarketCitizenSpawnSystem extends BaseComponentSystem {
 
                 DialogResponse buyResponse = new DialogResponse();
                 buyResponse.action = new ArrayList<>();
-                buyResponse.action.add(new ShowMarketScreenAction(marketComponent.market.getId(), TransactionType.BUYING));
+                buyResponse.action.add(new ShowMarketScreenAction(marketComponent.getMarketId(), TransactionType.BUYING));
                 buyResponse.text = "Buy";
 
                 DialogResponse sellResponse = new DialogResponse();
                 sellResponse.action = new ArrayList<>();
-                sellResponse.action.add(new ShowMarketScreenAction(marketComponent.market.getId(), TransactionType.SELLING));
+                sellResponse.action.add(new ShowMarketScreenAction(marketComponent.getMarketId(), TransactionType.SELLING));
                 sellResponse.text = "Sell";
 
                 DialogResponse closeResponse = new DialogResponse();

--- a/src/main/java/org/terasology/metalrenegades/economy/systems/MarketManagementSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/systems/MarketManagementSystem.java
@@ -28,30 +28,26 @@ import org.terasology.dynamicCities.population.PopulationComponent;
 import org.terasology.dynamicCities.settlements.components.ActiveSettlementComponent;
 import org.terasology.dynamicCities.settlements.components.MarketComponent;
 import org.terasology.dynamicCities.settlements.events.SettlementRegisterEvent;
-import org.terasology.economy.components.InfiniteStorageComponent;
-import org.terasology.economy.components.MarketSubscriberComponent;
-import org.terasology.economy.components.MultiInvStorageComponent;
-import org.terasology.economy.events.ResourceDrawEvent;
-import org.terasology.economy.events.ResourceInfoRequestEvent;
-import org.terasology.economy.events.ResourceStoreEvent;
-import org.terasology.economy.events.SubscriberRegistrationEvent;
-import org.terasology.economy.events.UpdateWalletEvent;
+import org.terasology.economy.components.*;
+import org.terasology.economy.events.*;
 import org.terasology.economy.handler.MultiInvStorageHandler;
 import org.terasology.economy.systems.MarketLogisticSystem;
-import org.terasology.economy.systems.WalletSystem;
+import org.terasology.economy.systems.WalletAuthoritySystem;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
-import org.terasology.logic.players.LocalPlayer;
+import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
+import org.terasology.metalrenegades.economy.events.MarketTransactionRequest;
 import org.terasology.metalrenegades.economy.events.TransactionType;
 import org.terasology.metalrenegades.economy.ui.MarketItem;
-import org.terasology.network.ClientComponent;
+import org.terasology.network.NetworkComponent;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 import org.terasology.world.block.BlockManager;
@@ -63,7 +59,7 @@ import java.util.Set;
  * Handles most core market features
  */
 @Share(MarketManagementSystem.class)
-@RegisterSystem
+@RegisterSystem(RegisterMode.AUTHORITY)
 public class MarketManagementSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 
     @In
@@ -82,9 +78,6 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
     private InventoryManager inventoryManager;
 
     @In
-    private LocalPlayer localPlayer;
-
-    @In
     private BlockCommands blockCommands;
 
     @In
@@ -94,19 +87,20 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
     private MultiInvStorageHandler handler;
 
     @In
-    private WalletSystem walletSystem;
-
-    private EntityRef playerResourceStore;
+    private WalletAuthoritySystem walletAuthoritySystem;
 
     private final int COOLDOWN = 200;
     private int counter = 0;
 
     private Logger logger = LoggerFactory.getLogger(MarketManagementSystem.class);
 
-    @Override
-    public void postBegin() {
-        playerResourceStore = entityManager.create();
+    @ReceiveEvent
+    public void onPlayerJoin(OnPlayerSpawnedEvent onPlayerSpawnedEvent, EntityRef player) {
+        EntityRef playerResourceStore = entityManager.create();
         playerResourceStore.addComponent(new InfiniteStorageComponent(1));
+        playerResourceStore.setOwner(player);
+
+        player.addComponent(new PlayerResourceStoreComponent(playerResourceStore));
     }
 
     @Override
@@ -139,7 +133,9 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
     @ReceiveEvent(components = {ActiveSettlementComponent.class, PopulationComponent.class, CultureComponent.class})
     public void onSettlementSpawnEvent(SettlementRegisterEvent event, EntityRef settlement) {
         EntityRef market = entityManager.create(new InfiniteStorageComponent(1));
+        settlement.addComponent(new NetworkComponent());
         MarketComponent marketComponent = new MarketComponent(market);
+        marketComponent.marketId = market.getId();
         settlement.addComponent(marketComponent);
     }
 
@@ -156,37 +152,28 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
         entityRef.send(new SubscriberRegistrationEvent());
     }
 
-    // TODO: Expose transaction logic as events
-//    @ReceiveEvent
-//    public void onMarketTransactionConfirm(MarketTransactionEvent event, EntityRef character) {
-//
-//    }
-
     /**
      * Initiate a transaction and delegate to an appropriate method depending
      * on the nature of the transaction
-     * @param item MarketItem to be bought/sold
-     * @param type TransactionType
-     * @return updated MarketItem
      */
-    public MarketItem handleTransaction(MarketItem item, TransactionType type) {
-        if (type == TransactionType.BUYING) {
-            return buy(item);
-        } else if (type == TransactionType.SELLING) {
-            return sell(item);
+    @ReceiveEvent
+    public void onMarketTransactionRequest(MarketTransactionRequest request, EntityRef character) {
+        if (request.type == TransactionType.BUYING) {
+            buy(character, request.item);
+        } else if (request.type == TransactionType.SELLING) {
+            sell(character, request.item);
         } else {
             logger.warn("TransactionType invalid");
-            return item;
         }
     }
 
-    private MarketItem buy(MarketItem item) {
-        if (!walletSystem.isValidTransaction(-1 * item.cost)) {
+    private MarketItem buy(EntityRef character, MarketItem item) {
+        if (!walletAuthoritySystem.isValidTransaction(character,-1 * item.cost)) {
             logger.warn("Insufficient funds");
             return item;
         } else if (item.quantity > 0) {
 
-            if (!createItemOrBlock(item.name)) {
+            if (!createItemOrBlock(character, item.name)) {
                 logger.warn("Failed to create entity");
                 return item;
             }
@@ -197,6 +184,7 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
                     continue;
                 }
 
+                EntityRef playerResourceStore = character.getComponent(PlayerResourceStoreComponent.class).resourceStore;
                 MultiInvStorageComponent component = bldg.getComponent(MultiInvStorageComponent.class);
 
                 playerResourceStore.send(new ResourceDrawEvent(item.name, 1, bldg));
@@ -206,7 +194,7 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
                         handler.availableResourceAmount(component, item.name));
 
                 item.quantity--;
-                localPlayer.getCharacterEntity().send(new UpdateWalletEvent(-1 * item.cost));
+                character.send(new WalletTransactionEvent(-1 * item.cost));
                 break;
             }
 
@@ -215,8 +203,8 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
         return item;
     }
 
-    private MarketItem sell(MarketItem item) {
-        if (item.quantity <=0 || !destroyItemOrBlock(item.name)) {
+    private MarketItem sell(EntityRef character, MarketItem item) {
+        if (item.quantity <=0 || !destroyItemOrBlock(character, item.name)) {
             logger.warn("Failed to create entity");
             return item;
         }
@@ -227,10 +215,12 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
                 continue;
             }
 
+            EntityRef playerResourceStore = character.getComponent(PlayerResourceStoreComponent.class).resourceStore;
             SettlementRefComponent settlementRefComponent = bldg.getComponent(SettlementRefComponent.class);
+
             playerResourceStore.send(new ResourceStoreEvent(item.name, 1, settlementRefComponent.settlement.getComponent(MarketComponent.class).market));
             item.quantity--;
-            localPlayer.getCharacterEntity().send(new UpdateWalletEvent(item.cost));
+            character.send(new WalletTransactionEvent(item.cost));
             break;
         }
 
@@ -243,22 +233,23 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
      * @param name Name of the item bought
      * @return Boolean indication whether the creating was a success or a failure
      */
-    private boolean createItemOrBlock(String name) {
+    private boolean createItemOrBlock(EntityRef character, String name) {
         Set<ResourceUrn> matches = assetManager.resolve(name, Prefab.class);
+        String itemURI = "";
 
         if (matches.size() == 1) {
             Prefab prefab = assetManager.getAsset(matches.iterator().next(), Prefab.class).orElse(null);
+            itemURI = prefab.getUrn().getModuleName() + ":" + name;
             if (prefab != null && prefab.getComponent(ItemComponent.class) != null) {
-                EntityRef playerEntity = localPlayer.getClientEntity().getComponent(ClientComponent.class).character;
                 EntityRef entity = entityManager.create(prefab);
-                if (!inventoryManager.giveItem(playerEntity, playerEntity, entity)) {
+                if (!inventoryManager.giveItem(character, character, entity)) {
                     entity.destroy();
                     return true;
                 }
             }
         }
 
-        String message = blockCommands.giveBlock(localPlayer.getClientEntity(), name, 1, null);
+        String message = blockCommands.giveBlock(character.getOwner(), itemURI, 1, null);
         if (message != null) {
             return true;
         }
@@ -271,18 +262,17 @@ public class MarketManagementSystem extends BaseComponentSystem implements Updat
      * @param name Name of the item sold
      * @return Boolean indication whether the removal was a success or a failure
      */
-    private boolean destroyItemOrBlock(String name) {
-        EntityRef player = localPlayer.getCharacterEntity();
+    private boolean destroyItemOrBlock(EntityRef character, String name) {
         EntityRef item = EntityRef.NULL;
         try {
-            for (int i = 0; i < inventoryManager.getNumSlots(player); i++) {
-                EntityRef current = inventoryManager.getItemInSlot(player, i);
+            for (int i = 0; i < inventoryManager.getNumSlots(character); i++) {
+                EntityRef current = inventoryManager.getItemInSlot(character, i);
                 if (!EntityRef.NULL.equals(current) && name.equalsIgnoreCase(current.getParentPrefab().getName())) {
                     item = current;
                     break;
                 }
             }
-            inventoryManager.removeItem(localPlayer.getCharacterEntity(), EntityRef.NULL, item, true, 1);
+            inventoryManager.removeItem(character, EntityRef.NULL, item, true, 1);
         } catch (Exception e) {
             logger.error("Could not create entity from {}. Exception: {}", name, e.getMessage());
             return false;

--- a/src/main/java/org/terasology/metalrenegades/economy/ui/MarketScreen.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/ui/MarketScreen.java
@@ -18,6 +18,7 @@ package org.terasology.metalrenegades.economy.ui;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.metalrenegades.economy.events.MarketTransactionRequest;
 import org.terasology.metalrenegades.economy.events.TransactionType;
 import org.terasology.metalrenegades.economy.systems.MarketManagementSystem;
 import org.terasology.registry.In;
@@ -129,9 +130,10 @@ public class MarketScreen extends CoreScreenLayer {
         confirm = find("confirm", UIButton.class);
         confirm.subscribe((widget -> {
             if (type == TransactionType.BUYING || type == TransactionType.SELLING) {
-                // TODO: Expose transaction logic as events
-//                player.getCharacterEntity().send(new MarketTransactionEvent(selected, type));
-                selected = marketManagementSystem.handleTransaction(selected, type);
+                MarketTransactionRequest marketTransactionRequest = new MarketTransactionRequest();
+                marketTransactionRequest.item = selected;
+                marketTransactionRequest.type = type;
+                player.getCharacterEntity().send(marketTransactionRequest);
                 logger.info("Confirmed transaction of one {}", selected.name);
             } else {
                 logger.warn("TransactionType not recognised. No transaction.");

--- a/src/main/java/org/terasology/metalrenegades/economy/ui/MarketScreen.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/ui/MarketScreen.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.metalrenegades.economy.events.MarketTransactionRequest;
 import org.terasology.metalrenegades.economy.events.TransactionType;
+import org.terasology.metalrenegades.economy.events.UpdateMarketScreenEvent;
 import org.terasology.metalrenegades.economy.systems.MarketManagementSystem;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
@@ -135,6 +136,7 @@ public class MarketScreen extends CoreScreenLayer {
                 marketTransactionRequest.type = type;
                 player.getCharacterEntity().send(marketTransactionRequest);
                 logger.info("Confirmed transaction of one {}", selected.name);
+                player.getCharacterEntity().send(new UpdateMarketScreenEvent());
             } else {
                 logger.warn("TransactionType not recognised. No transaction.");
             }

--- a/src/main/java/org/terasology/metalrenegades/economy/ui/MarketUISystem.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/ui/MarketUISystem.java
@@ -34,6 +34,7 @@ import org.terasology.metalrenegades.economy.events.TransactionType;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 import org.terasology.rendering.nui.NUIManager;
+import org.terasology.world.block.items.BlockItemComponent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,7 +92,13 @@ public class MarketUISystem extends BaseComponentSystem {
             for (int i = 0; i < slots; i++) {
                 EntityRef entity = inventoryManager.getItemInSlot(player, i);
                 if (entity.getParentPrefab() != null) {
-                    MarketItem item = MarketItemBuilder.get(entity.getParentPrefab().getName(), 1); // TODO: 1?
+                    MarketItem item;
+                    logger.info(entity.getParentPrefab().getName() + " == " + "blockItemBase");
+                    if (entity.getParentPrefab().getName().equalsIgnoreCase("engine:blockItemBase")) {
+                        item = MarketItemBuilder.get(entity.getComponent(BlockItemComponent.class).blockFamily.getURI().toString(), inventoryManager.getStackSize(entity));
+                    } else {
+                        item = MarketItemBuilder.get(entity.getParentPrefab().getName(), inventoryManager.getStackSize(entity));
+                    }
                     marketItemList.add(item);
                 }
             }

--- a/src/main/java/org/terasology/metalrenegades/economy/ui/MarketUISystem.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/ui/MarketUISystem.java
@@ -36,6 +36,7 @@ import org.terasology.registry.In;
 import org.terasology.registry.Share;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.world.block.items.BlockItemComponent;
+import org.terasology.world.time.WorldTimeEvent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,6 +72,13 @@ public class MarketUISystem extends BaseComponentSystem {
     @Override
     public void initialise() {
         marketScreen = (MarketScreen) nuiManager.createScreen("MetalRenegades:marketScreen");
+    }
+
+    @ReceiveEvent
+    public void onWorldTimeCycle(WorldTimeEvent worldTimeEvent, EntityRef entity) {
+        if (marketID != 0 && type != null) {
+            updateScreenInformation();
+        }
     }
 
     @ReceiveEvent

--- a/src/main/java/org/terasology/metalrenegades/quests/FetchQuestSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/quests/FetchQuestSystem.java
@@ -20,7 +20,7 @@ import org.terasology.dynamicCities.buildings.components.DynParcelRefComponent;
 import org.terasology.dynamicCities.buildings.components.SettlementRefComponent;
 import org.terasology.dynamicCities.construction.events.BuildingEntitySpawnedEvent;
 import org.terasology.dynamicCities.parcels.DynParcel;
-import org.terasology.economy.events.UpdateWalletEvent;
+import org.terasology.economy.events.WalletTransactionEvent;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -173,7 +173,7 @@ public class FetchQuestSystem extends BaseComponentSystem {
             inventoryManager.removeItem(character, EntityRef.NULL, item, true, amounts.getOrDefault(ITEM_ID, 0));
 
             // Pay the player
-            character.send(new UpdateWalletEvent(REWARD));
+            character.send(new WalletTransactionEvent(REWARD));
 
             // Remove the minmap overlay
             character.send(new RemoveBeaconOverlayEvent(activeQuestEntity));


### PR DESCRIPTION
Fixes various operations of the city marketplaces, so the player can access items in multiplayer mode the same as in singleplayer mode. Tested with the client "host game" option and with a headless server.
Also fixes some aspects of the market UI, to fix some responsiveness issues.

<h3>Known Issues</h3>

- The market system works on entity IDs, which are not consistant between server-client. This was addressed by saving the entity ID in a component, but this may change on reloading a game. This cannot be tested, since all characters (including the market character) disappear when a game is reloaded, and cannot be interacted with.

**Requires [Terasology/Economy#14](https://github.com/Terasology/Economy/pull/14) and [Terasology/DynamicCities#65](https://github.com/Terasology/DynamicCities/pull/65) to work.**

Closes #32 