### PR TITLE
Fix needs system to play on multiplayer and serialize properly

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/ai/actions/CheckNeedAction.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/actions/CheckNeedAction.java
@@ -39,7 +39,24 @@ public class CheckNeedAction extends BaseAction {
         CitizenNeed.Type needTypeValue = CitizenNeed.Type.valueOf(needType);
 
         NeedsComponent needsComponent = actor.getComponent(NeedsComponent.class);
-        CitizenNeed currentNeed = needsComponent.needs.get(needTypeValue);
+        CitizenNeed currentNeed;
+
+        switch (needTypeValue) {
+            case FOOD:
+                currentNeed = needsComponent.hungerNeed;
+                break;
+            case WATER:
+                currentNeed = needsComponent.thirstNeed;
+                break;
+            case SOCIAL:
+                currentNeed = needsComponent.socialNeed;
+                break;
+            case REST:
+                currentNeed = needsComponent.restNeed;
+                break;
+            default:
+                return BehaviorState.FAILURE;
+        }
 
         return currentNeed.isBelowGoal() ? BehaviorState.SUCCESS : BehaviorState.FAILURE;
     }

--- a/src/main/java/org/terasology/metalrenegades/ai/actions/FulfillNeedAction.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/actions/FulfillNeedAction.java
@@ -36,7 +36,23 @@ public class FulfillNeedAction extends BaseAction {
         CitizenNeed.Type needTypeValue = CitizenNeed.Type.valueOf(needType);
 
         NeedsComponent needsComponent = actor.getComponent(NeedsComponent.class);
-        needsComponent.needs.get(needTypeValue).restoreNeed();
+
+        switch (needTypeValue) {
+            case FOOD:
+                needsComponent.hungerNeed.restoreNeed();
+                break;
+            case WATER:
+                needsComponent.thirstNeed.restoreNeed();
+                break;
+            case SOCIAL:
+                needsComponent.socialNeed.restoreNeed();
+                break;
+            case REST:
+                needsComponent.restNeed.restoreNeed();
+                break;
+            default:
+                return BehaviorState.FAILURE;
+        }
 
         actor.save(needsComponent);
         actor.getEntity().removeComponent(FollowComponent.class);

--- a/src/main/java/org/terasology/metalrenegades/ai/component/NeedsComponent.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/component/NeedsComponent.java
@@ -17,6 +17,7 @@ package org.terasology.metalrenegades.ai.component;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.metalrenegades.ai.CitizenNeed;
+import org.terasology.network.Replicate;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -26,6 +27,27 @@ import java.util.Map;
  */
 public class NeedsComponent implements Component {
 
-    public Map<CitizenNeed.Type, CitizenNeed> needs = new EnumMap<>(CitizenNeed.Type.class);
+    @Replicate
+    public CitizenNeed hungerNeed;
+
+    @Replicate
+    public CitizenNeed thirstNeed;
+
+    @Replicate
+    public CitizenNeed socialNeed;
+
+    @Replicate
+    public CitizenNeed restNeed;
+
+    public NeedsComponent(CitizenNeed hunger, CitizenNeed thirst, CitizenNeed social, CitizenNeed rest) {
+        this.hungerNeed = hunger;
+        this.thirstNeed = thirst;
+        this.socialNeed = social;
+        this.restNeed = rest;
+    }
+
+    public NeedsComponent() {
+
+    }
 
 }

--- a/src/main/java/org/terasology/metalrenegades/ai/system/CitizenSpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/CitizenSpawnSystem.java
@@ -122,12 +122,11 @@ public class CitizenSpawnSystem extends BaseComponentSystem implements UpdateSub
         entityBuilder.addComponent(homeComponent);
         entityBuilder.saveComponent(citizenLocationComponent);
 
-        NeedsComponent needsComponent = new NeedsComponent();
-
-        needsComponent.needs.put(CitizenNeed.Type.FOOD, new CitizenNeed(20, 0.5f, 5, 15));
-        needsComponent.needs.put(CitizenNeed.Type.WATER, new CitizenNeed(20, 1, 8, 20));
-        needsComponent.needs.put(CitizenNeed.Type.SOCIAL, new CitizenNeed(30, 1, 15, 30));
-        needsComponent.needs.put(CitizenNeed.Type.REST, new CitizenNeed(50, 0.5f, 20, 50));
+        NeedsComponent needsComponent = new NeedsComponent(
+                new CitizenNeed(20, 0.5f, 5, 15), // hunger
+                new CitizenNeed(20, 1, 8, 20), // thirst
+                new CitizenNeed(30, 1, 15, 30), // social
+                new CitizenNeed(50, 0.5f, 20, 50)); // rest
 
         entityBuilder.saveComponent(needsComponent);
         entityBuilder.addComponent(new TraderComponent());

--- a/src/main/java/org/terasology/metalrenegades/ai/system/CitizenTooltipSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/CitizenTooltipSystem.java
@@ -47,7 +47,10 @@ public class CitizenTooltipSystem extends BaseComponentSystem {
 
     @ReceiveEvent(components = NeedsComponent.class)
     public void addNeedsToTooltip(GetItemTooltip event, EntityRef entity, NeedsComponent needsComponent) {
-        needsComponent.needs.forEach((k, v) -> event.getTooltipLines().add(new TooltipLine(k.toString() + " " + v.toString())));
+        event.getTooltipLines().add(new TooltipLine("Hunger: " + needsComponent.hungerNeed.toString()));
+        event.getTooltipLines().add(new TooltipLine("Thirst: " + needsComponent.thirstNeed.toString()));
+        event.getTooltipLines().add(new TooltipLine("Social: " + needsComponent.socialNeed.toString()));
+        event.getTooltipLines().add(new TooltipLine("Rest: " + needsComponent.restNeed.toString()));
     }
 
     @ReceiveEvent(components = CitizenComponent.class)

--- a/src/main/java/org/terasology/metalrenegades/ai/system/NeedsSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/NeedsSystem.java
@@ -41,7 +41,10 @@ public class NeedsSystem extends BaseComponentSystem {
         for (EntityRef entity : entityManager.getEntitiesWith(NeedsComponent.class)) {
             NeedsComponent needsComponent = entity.getComponent(NeedsComponent.class);
 
-            needsComponent.needs.forEach((k, v) -> v.runNeedCycle());
+            needsComponent.hungerNeed.runNeedCycle();
+            needsComponent.thirstNeed.runNeedCycle();
+            needsComponent.socialNeed.runNeedCycle();
+            needsComponent.restNeed.runNeedCycle();
 
             entity.saveComponent(needsComponent);
         }


### PR DESCRIPTION
The needs system used to use a needs component attached to all character with a field of type `Map<CitizenNeed.Type, CitizenNeed>`. This field could not be serialized, so therefore the needs system wouldn't work in multiplayer, and any time that the character is unloaded (by walking away) the needs system would fail. This pull request fixes the need component to use serializable data types.

<h3>Testing Instructions</h3>

- Create a headless server with Metal Renegades enabled.
- Join the game on a client, and search until you find a city.
- Look at a character. The tooltip should tell you if the NeedsComponent has replicated properly:

![image](https://user-images.githubusercontent.com/44126397/87258580-3ce8c580-c47f-11ea-8e83-f4eaf58c77c4.png)
_If all the details are shown like above, then the replication worked._

![image](https://user-images.githubusercontent.com/44126397/87259048-fc8b4680-c482-11ea-999e-a918aaedb59f.png)
_If the details are hidden like above, then the replication did not work._

- If the replication worked, test further by moving far away from the city. Then, move up close again. If the serialization failed, then the IDEA console (on the host) should be filled with `CheckNeedAction` failures.


