### PR TITLE
Add new minerals to world generation

### DIFF
--- a/assets/prefabs/generation/oreDefinitions/coalOreDefinition.prefab
+++ b/assets/prefabs/generation/oreDefinitions/coalOreDefinition.prefab
@@ -1,0 +1,12 @@
+{
+  "OreGenDefinition": {},
+  "PocketDensityOreGen": {
+    "block": "CoreAssets:CoalOre",
+    //  What block will be placed
+    "frequency": 4,
+    // How often this pocket will happen in 10 vertical blocks in the region
+    "radius": 1,
+    "thickness": 3,
+    "density": 0.5
+  }
+}

--- a/assets/prefabs/generation/oreDefinitions/copperOreDefinition.prefab
+++ b/assets/prefabs/generation/oreDefinitions/copperOreDefinition.prefab
@@ -1,0 +1,12 @@
+{
+  "OreGenDefinition": {},
+  "PocketDensityOreGen": {
+    "block": "CoreAssets:CopperOre",
+    //  What block will be placed
+    "frequency": 4,
+    // How often this pocket will happen in 10 vertical blocks in the region
+    "radius": 1,
+    "thickness": 3,
+    "density": 0.5
+  }
+}

--- a/assets/prefabs/generation/oreDefinitions/diamondOreDefinition.prefab
+++ b/assets/prefabs/generation/oreDefinitions/diamondOreDefinition.prefab
@@ -1,0 +1,12 @@
+{
+  "OreGenDefinition": {},
+  "PocketDensityOreGen": {
+    "block": "CoreAssets:DiamondOre",
+    //  What block will be placed
+    "frequency": 2,
+    // How often this pocket will happen in 10 vertical blocks in the region
+    "radius": 1,
+    "thickness": 3,
+    "density": 0.5
+  }
+}

--- a/assets/prefabs/generation/oreDefinitions/goldOreDefinition.prefab
+++ b/assets/prefabs/generation/oreDefinitions/goldOreDefinition.prefab
@@ -1,0 +1,12 @@
+{
+  "OreGenDefinition": {},
+  "PocketDensityOreGen": {
+    "block": "CoreAssets:GoldOre",
+    //  What block will be placed
+    "frequency": 2,
+    // How often this pocket will happen in 10 vertical blocks in the region
+    "radius": 1,
+    "thickness": 3,
+    "density": 0.5
+  }
+}

--- a/assets/prefabs/generation/oreDefinitions/ironOreDefinition.prefab
+++ b/assets/prefabs/generation/oreDefinitions/ironOreDefinition.prefab
@@ -1,9 +1,12 @@
 {
   "OreGenDefinition": {},
   "PocketDensityOreGen": {
-    "block": "CoreAssets:CoalOre",
+    "block": "CoreAssets:IronOre",
     //  What block will be placed
-    "frequency": 1
+    "frequency": 4,
     // How often this pocket will happen in 10 vertical blocks in the region
+    "radius": 1,
+    "thickness": 3,
+    "density": 0.5
   }
 }


### PR DESCRIPTION
Adds four more minerals to world generation in addition to the already existing coal ore:

- Copper Ore
- Iron Ore
- Goal Ore
- Diamond Ore

As well, the ore generation stats have been changed to generally boost generation. All ores are now much easier to find.