### PR TITLE
Fix move_to minimum distance in citizen behaviors

### DIFF
--- a/assets/behaviors/distanceFollow.behavior
+++ b/assets/behaviors/distanceFollow.behavior
@@ -23,7 +23,9 @@
             }
           }
         },
-        move_to
+        {
+          move_to: { distance: 2 }
+        }
       ]
     }
   ]


### PR DESCRIPTION
This PR changes the minimum distance that a citizen character must be within a target to complete the travel action. The minimum distance was changed from `0.2` -> `2`. This should cut down significantly on the amount of characters rotating in circles above a target location.