### PR TITLE
fix: Quick fixes for trading system

### DIFF
--- a/assets/prefabs/prices/playerTools.prefab
+++ b/assets/prefabs/prices/playerTools.prefab
@@ -5,7 +5,7 @@
             ["CoreAssets:pickaxe", "Pickaxe", "There's gold in them hills, and this tool will bring you to it.", "25"],
             ["CoreAssets:shovel", "Shovel", "There's lots of sand, so why not dig it?", "25"],
             ["CoreAssets:axe", "Axe", "Chop chop!", "25"],
-            ["CoreAdvancedAssets:dynamite", "Dynamite", "Fire in the hole!", "100"],
+            ["CoreAdvancedAssets:dynamite", "Dynamite", "Fire in the hole!", "75"],
             ["MetalRenegades:pistol", "Pistol", "Fires lead faster than the speed of sound.", "75"],
             ["MetalRenegades:bulletItem", "Bullets", "A gunslinger is useless without a gun, and a gun is useless without its bullets.", "10"],
             ["MetalRenegades:emptyCup", "Empty Cup", "Take your drinks with you on the go!", "20"],

--- a/src/main/java/org/terasology/metalrenegades/ai/system/CitizenSpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/system/CitizenSpawnSystem.java
@@ -144,7 +144,7 @@ public class CitizenSpawnSystem extends BaseComponentSystem implements UpdateSub
     }
 
     private void setupStartInventory(EntityRef citizen) {
-        Prefab railgun = prefabManager.getPrefab("CoreAdvancedAssets:gun");
+        Prefab railgun = prefabManager.getPrefab("CoreAdvancedAssets:dynamite");
         EntityRef item = entityManager.create(railgun);
         item.send(new GiveItemEvent(citizen));
     }

--- a/src/main/java/org/terasology/metalrenegades/economy/ui/TradingScreen.java
+++ b/src/main/java/org/terasology/metalrenegades/economy/ui/TradingScreen.java
@@ -69,7 +69,7 @@ public class TradingScreen extends CoreScreenLayer {
     /**
      * Selected items
      */
-    private MarketItem pSelected = marketItemRegistry.getEmpty();
+    private MarketItem pSelected;
     private MarketItem cSelected;
 
     /**
@@ -88,7 +88,7 @@ public class TradingScreen extends CoreScreenLayer {
         pList.setItemRenderer(new StringTextRenderer<MarketItem>() {
             @Override
             public String getString(MarketItem value) {
-                return value.name;
+                return value.displayName;
             }
         });
         pList.subscribeSelection(((widget, item) -> pSelected = item));
@@ -105,7 +105,7 @@ public class TradingScreen extends CoreScreenLayer {
         cList.setItemRenderer(new StringTextRenderer<MarketItem>() {
             @Override
             public String getString(MarketItem value) {
-                return value.name;
+                return value.displayName;
             }
         });
         cList.subscribeSelection(((widget, item) -> cSelected = item));


### PR DESCRIPTION
This pull request contains four small bug fixes relating to the trade system:

- Avoids a NPE when opening up the trade menu caused by initializing a value in `TradeUISystem` too early.
- Displays an item's display name rather than URI in the trade screen.
- Switches out a citizen's default `CoreAdvancedAssets:gun` (an overpowered item in this game with no market information) for 'CoreAdvanced:dynamite`.
- Lowers the price of dynamite to 75, the same as a pistol. At the old price of 100, the price was way too high to allow any valid trades.