### PR TITLE
feat: Allow hidden chest fill items to be defined in external config files

### DIFF
--- a/assets/prefabs/configs/foodItems.prefab
+++ b/assets/prefabs/configs/foodItems.prefab
@@ -11,5 +11,14 @@
             ["AdditionalVegetables:Potato", "Potatoes", "A brownish root vegetable, and a major ingredient in French Fries!", "10"],
             ["WildAnimals:meat", "Meat", "The meat of a deer found outside the city.", "20"]
         ]
+    },
+    "DiscoverableItemConfiguration": {
+        "items": [
+            ["AdditionalFruits:Blueberry", "5"],
+            ["AdditionalFruits:Raspberry", "5"],
+            ["AdditionalFruits:Strawberry", "5"],
+            ["AdditionalVegetables:Potato", "5"],
+            ["MetalRenegades:bulletItem", "5"]
+        ]
     }
 }

--- a/assets/prefabs/configs/oresAndBlocks.prefab
+++ b/assets/prefabs/configs/oresAndBlocks.prefab
@@ -9,5 +9,12 @@
             ["CoreAssets:Sand", "Sand", "Granular yellow substance, very common in the desert.", "1"],
             ["CoreAssets:Stone", "Stone", "Rocks. Strong rocks.", "1"]
         ]
+    },
+    "DiscoverableItemConfiguration": {
+        "items": [
+            ["MetalRenegades:emerald", "1"],
+            ["MetalRenegades:ruby", "1"],
+            ["MetalRenegades:sapphire", "1"]
+        ]
     }
 }

--- a/assets/prefabs/configs/playerTools.prefab
+++ b/assets/prefabs/configs/playerTools.prefab
@@ -11,5 +11,14 @@
             ["MetalRenegades:emptyCup", "Empty Cup", "Take your drinks with you on the go!", "20"],
             ["MetalRenegades:filledCup", "Filled Cup", "The perfect drink for a thirsty traveller.", "30"]
         ]
+    },
+    "DiscoverableItemConfiguration": {
+        "items": [
+            ["CoreAssets:pickaxe", "1"],
+            ["CoreAssets:axe", "1"],
+            ["CoreAssets:shovel", "1"],
+            ["MetalRenegades:emptyCup", "1"],
+            ["MetalRenegades:pistol", "1"]
+        ]
     }
 }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/ChestFillingSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/ChestFillingSystem.java
@@ -14,7 +14,6 @@ import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
-import org.terasology.metalrenegades.economy.systems.MarketCitizenSpawnSystem;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
@@ -109,12 +108,9 @@ public class ChestFillingSystem extends BaseComponentSystem implements UpdateSub
      * @return The chest slot item.
      */
     private EntityRef getSlotItem() {
-        if (hiddenItemsRegistry.isEmpty()) {
-            initialise();
-
-            if (hiddenItemsRegistry.isEmpty()) { // still empty after initialization? something must be wrong
-                logger.warn("No items in the hidden chest registry!");
-            }
+        if (hiddenItemsRegistry.isEmpty()) { // still empty after initialization? something must be wrong
+            logger.warn("No items in the hidden chest registry!");
+            return EntityRef.NULL;
         }
 
         Object[] itemURIs = hiddenItemsRegistry.keySet().toArray();

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/ChestFillingSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/ChestFillingSystem.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.world.dynamic.discoverables;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -11,9 +14,15 @@ import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.inventory.ItemComponent;
+import org.terasology.metalrenegades.economy.systems.MarketCitizenSpawnSystem;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.utilities.random.Random;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Checks for any chests that have a {@link DiscoverableChestComponent} attached and fills it with items.
@@ -21,45 +30,22 @@ import org.terasology.utilities.random.Random;
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class ChestFillingSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 
-    /**
-     * Items that generate in chests as stacks of five.
-     */
-    private final String[] bulkItems = {
-            "AdditionalFruits:Blueberry",
-            "AdditionalFruits:Raspberry",
-            "AdditionalFruits:Strawberry",
-            "AdditionalVegetables:Potato",
-            "MetalRenegades:bulletItem"
-    };
-
-    /**
-     * Items that generate in chests as stacks of one.
-     */
-    private final String[] singleItems = {
-            "CoreAssets:pickaxe",
-            "CoreAssets:axe",
-            "CoreAssets:shovel",
-            "MetalRenegades:emptyCup",
-            "MetalRenegades:pistol",
-            "MetalRenegades:emerald",
-            "MetalRenegades:ruby",
-            "MetalRenegades:sapphire"
-    };
+    private Logger logger = LoggerFactory.getLogger(ChestFillingSystem.class);
 
     /**
      * The chance out of one that any particular chest slot will contain an item.
      */
     private static final float ITEM_CHANCE = 0.08f;
 
-    /**
-     * The chance out of one that a chest slot with an item in it will be a bulk item vs. a single item.
-     */
-    private static final float BULK_SINGLE_RATIO = 0.75f;
+    private Map<String, Integer> hiddenItemsRegistry = new HashMap<>();
 
     /**
      * The random number provider that determines the items generated inside a discoverable chest.
      */
     private Random random;
+
+    @In
+    private PrefabManager prefabManager;
 
     @In
     private EntityManager entityManager;
@@ -70,6 +56,17 @@ public class ChestFillingSystem extends BaseComponentSystem implements UpdateSub
     @Override
     public void initialise() {
         random = new FastRandom();
+
+        prefabManager.listPrefabs(DiscoverableItemConfigurationComponent.class).stream().forEach(prefab -> {
+            DiscoverableItemConfigurationComponent itemDef =
+                    prefab.getComponent(DiscoverableItemConfigurationComponent.class);
+
+            List<List<String>> configs = itemDef.items;
+            configs.stream().forEach(config -> {
+                Iterator<String> it = config.iterator();
+                hiddenItemsRegistry.put(it.next(), Integer.parseInt(it.next()));
+            });
+        });
     }
 
     @Override
@@ -112,15 +109,22 @@ public class ChestFillingSystem extends BaseComponentSystem implements UpdateSub
      * @return The chest slot item.
      */
     private EntityRef getSlotItem() {
-        EntityRef item;
-        if (random.nextFloat() < BULK_SINGLE_RATIO) {
-            item = entityManager.create(bulkItems[random.nextInt(bulkItems.length)]);
-            ItemComponent itemComponent = item.getComponent(ItemComponent.class);
-            itemComponent.stackCount = 5;
-            item.saveComponent(itemComponent);
-        } else {
-            item = entityManager.create(singleItems[random.nextInt(singleItems.length)]);
+        if (hiddenItemsRegistry.isEmpty()) {
+            initialise();
+
+            if (hiddenItemsRegistry.isEmpty()) { // still empty after initialization? something must be wrong
+                logger.warn("No items in the hidden chest registry!");
+            }
         }
+
+        Object[] itemURIs = hiddenItemsRegistry.keySet().toArray();
+        String randomURI = (String) itemURIs[random.nextInt(itemURIs.length)];
+
+        EntityRef item = entityManager.create(randomURI);
+        ItemComponent itemComponent = item.getComponent(ItemComponent.class);
+        itemComponent.stackCount = hiddenItemsRegistry.get(randomURI).byteValue();
+        item.saveComponent(itemComponent);
+
         return item;
     }
 }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverableItemConfigurationComponent.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverableItemConfigurationComponent.java
@@ -1,0 +1,17 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.world.dynamic.discoverables;
+
+import org.terasology.entitySystem.Component;
+
+import java.util.List;
+
+public class DiscoverableItemConfigurationComponent implements Component {
+
+    /**
+     * A list of all item definitions that can be generated in hidden chests.
+     */
+    public List<List<String>> items;
+
+}

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
@@ -35,19 +35,20 @@ public class DiscoverablesProvider implements FacetProvider {
     public void process(GeneratingRegion region) {
         Border3D border = region.getBorderForFacet(DiscoverablesFacet.class).extendBy(1, 0, 1);
 
-        SurfaceHeightFacet surfaceHeightFacet = region.getRegionFacet(SurfaceHeightFacet.class);
         DiscoverablesFacet facet = new DiscoverablesFacet(region.getRegion(), border);
+        SurfaceHeightFacet surfaceHeightFacet = region.getRegionFacet(SurfaceHeightFacet.class);
 
         Rect2i worldRegion = surfaceHeightFacet.getWorldRegion();
 
         for (int wz = worldRegion.minY(); wz <= worldRegion.maxY(); wz++) {
             for (int wx = worldRegion.minX(); wx <= worldRegion.maxX(); wx++) {
-                int surfaceHeight = TeraMath.floorToInt(surfaceHeightFacet.getWorld(wx, wz));
+                int surfaceHeight = TeraMath.floorToInt(surfaceHeightFacet.getWorld(wx, wz)) + 1;
 
                 if (surfaceHeight >= facet.getWorldRegion().minY() &&
-                    surfaceHeight <= facet.getWorldRegion().maxY()) {
+                    surfaceHeight <= facet.getWorldRegion().maxY() &&
+                    facet.getWorldRegion().encompasses(wx, surfaceHeight, wz)) {
                     if (noise.noise(wx, wz) < (CHEST_PROBABILITY * 2) - 1) {
-                        facet.setWorld(wx, surfaceHeight + 1, wz, new DiscoverablesChest());
+                        facet.setWorld(wx, surfaceHeight, wz, new DiscoverablesChest());
                     }
                 }
             }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.world.dynamic.discoverables;
 
-import org.terasology.math.Region3i;
 import org.terasology.math.TeraMath;
+import org.terasology.math.geom.Rect2i;
 import org.terasology.utilities.procedural.Noise;
 import org.terasology.utilities.procedural.WhiteNoise;
 import org.terasology.world.generation.*;
@@ -13,13 +13,13 @@ import org.terasology.world.generation.facets.SurfaceHeightFacet;
  * Places chests into {@link DiscoverablesFacet} across the surface of the game world
  */
 @Produces(DiscoverablesFacet.class)
-@Requires(@Facet(value = SurfaceHeightFacet.class))
+@Requires(@Facet(value = SurfaceHeightFacet.class, border = @FacetBorder(sides=1, top=1)))
 public class DiscoverablesProvider implements FacetProvider {
 
     /**
      * The probability out of one that a chest will be placed on any particular surface block.
      */
-    public final static float CHEST_PROBABILITY = 0.00005f;
+    public static final float CHEST_PROBABILITY = 0.00005f;
 
     /**
      * A noise provider that determines the positions of discoverables.
@@ -33,17 +33,19 @@ public class DiscoverablesProvider implements FacetProvider {
 
     @Override
     public void process(GeneratingRegion region) {
+        Border3D border = region.getBorderForFacet(DiscoverablesFacet.class).extendBy(1, 0, 1);
+
         SurfaceHeightFacet surfaceHeightFacet = region.getRegionFacet(SurfaceHeightFacet.class);
-        DiscoverablesFacet facet = new DiscoverablesFacet(region.getRegion(), region.getBorderForFacet(DiscoverablesFacet.class));
+        DiscoverablesFacet facet = new DiscoverablesFacet(region.getRegion(), border);
 
-        Region3i worldRegion = facet.getWorldRegion();
+        Rect2i worldRegion = surfaceHeightFacet.getWorldRegion();
 
-        for (int wz = worldRegion.minZ(); wz <= worldRegion.maxZ(); wz++) {
+        for (int wz = worldRegion.minY(); wz <= worldRegion.maxY(); wz++) {
             for (int wx = worldRegion.minX(); wx <= worldRegion.maxX(); wx++) {
                 int surfaceHeight = TeraMath.floorToInt(surfaceHeightFacet.getWorld(wx, wz));
 
-                if (surfaceHeight > facet.getWorldRegion().minY() &&
-                    surfaceHeight < facet.getWorldRegion().maxY()) {
+                if (surfaceHeight >= facet.getWorldRegion().minY() &&
+                    surfaceHeight <= facet.getWorldRegion().maxY()) {
                     if (noise.noise(wx, wz) < (CHEST_PROBABILITY * 2) - 1) {
                         facet.setWorld(wx, surfaceHeight + 1, wz, new DiscoverablesChest());
                     }


### PR DESCRIPTION
Allows hidden chest item definition to happen in external config files, rather than lists inside `ChestFillingSystem`. These configurations are marked inside `.prefab` files with a `DiscoverableItemConfigurationComponent`, with each item defined as an array of four strings in the form [itemURI, itemQuantity]. These configurations are combined and used together to determine the items that will appear in each chest.

These definitions have been included in the three general item prefabs created as part of #86, alongside the price definitions for similar items.