### PR TITLE
Nighttime enemy avoidance of city areas

### DIFF
--- a/assets/behaviors/enemyHostile.behavior
+++ b/assets/behaviors/enemyHostile.behavior
@@ -1,0 +1,37 @@
+{
+  dynamic: [
+    {
+      sequence: [
+        inside_city_check,
+        {
+          guard: {
+            componentPresent: "Behaviors:FindNearbyPlayers",
+            values: ["N charactersWithinRange nonEmpty"],
+            child: {
+              sequence: [
+                { sleep: {time: 0.1f }},
+                flee_from_character,
+                { lookup: {tree: "Behaviors:flee" }}
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      guard: {
+        componentPresent: "Behaviors:FindNearbyPlayers",
+        values: ["N charactersWithinRange nonEmpty"],
+        child: {
+          sequence: [
+            { sleep: {time: 0.1f }},
+            followCharacter,
+            { lookup: {tree: "Behaviors:hostile" }}
+
+          ]
+        }
+      }
+    },
+    { lookup: { tree: "Behaviors:stray" }}
+  ]
+}

--- a/assets/behaviors/enemyHostile.behavior
+++ b/assets/behaviors/enemyHostile.behavior
@@ -27,7 +27,6 @@
             { sleep: {time: 0.1f }},
             followCharacter,
             { lookup: {tree: "Behaviors:hostile" }}
-
           ]
         }
       }

--- a/assets/prefabs/characters/enemyGooey.prefab
+++ b/assets/prefabs/characters/enemyGooey.prefab
@@ -1,0 +1,95 @@
+{
+  "skeletalmesh": {
+    "mesh": "MawGooey:mawgooey",
+    "heightOffset": -0.8,
+    "material": "MawGooey:mawgooeySkin",
+    "animation": "MawGooey:mawgooeyIdleFinal",
+    "loop": true
+  },
+  "DropGrammar": {
+    "blockDrops": [],
+    "itemDrops": [
+      "2*WildAnimals:meat"
+    ]
+  },
+  "Stand": {
+    "animationPool": [
+      "MawGooey:mawgooeyIdleFinal"
+    ]
+  },
+  "Walk": {
+    "animationPool": [
+      "MawGooey:mawgooeyWalk"
+    ]
+  },
+  "MeleeAttack": {
+    "animationPool": [
+      "MawGooey:mawgooeyAttack"
+    ]
+  },
+  "Die": {
+    "animationPool": [
+      "MawGooey:mawgooeyDeath"
+    ]
+  },
+  "persisted": true,
+  "location": {},
+  "Character": {},
+  "AliveCharacter": {},
+  "WildAnimal": {
+    "name": "MawGooey",
+    "icon": "WildAnimals:mawgooeyIcon"
+  },
+  "NPCMovement": {},
+  "CreatureNameGenerator": {
+    "genderRatio": 0.5,
+    "nobility": 0.5,
+    "theme": "DWARF"
+  },
+  "CharacterMovement": {
+    "groundFriction": 16,
+    "speedMultiplier": 0.3,
+    "distanceBetweenFootsteps": 0.2,
+    "distanceBetweenSwimStrokes": 2.5,
+    "height": 1.6,
+    "radius": 0.3,
+    "jumpSpeed": 12
+  },
+  "CharacterSound": {
+    "footstepSounds": [
+      "FootGrass1",
+      "FootGrass2",
+      "FootGrass3",
+      "FootGrass4",
+      "FootGrass5"
+    ],
+    "footstepVolume": 0.03
+  },
+  "Network": {},
+  "MinionMove": {},
+  "Health": {
+    "maxHealth": 50,
+    "currentHealth": 50,
+    "destroyEntityOnNoHealth": true
+  },
+  "BoxShape": {
+    "extents": [
+      1.5,
+      1.5,
+      1.5
+    ]
+  },
+  "Trigger": {
+    "detectGroups": [
+      "engine:debris",
+      "engine:sensor"
+    ]
+  },
+  "Follow": {},
+  "FindNearbyPlayers": {
+    "searchRadius" : 7
+  },
+  "Behavior": {
+    "tree": "MetalRenegades:enemyHostile"
+  }
+}

--- a/src/main/java/org/terasology/metalrenegades/ai/actions/InsideCityCheckAction.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/actions/InsideCityCheckAction.java
@@ -14,6 +14,10 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 
+/**
+ * Checks if a character currently within the bounds of a city or not. Succeeds if the character is inside a city,
+ * false otherwise.
+ */
 @BehaviorAction(name = "inside_city_check")
 public class InsideCityCheckAction extends BaseAction {
 

--- a/src/main/java/org/terasology/metalrenegades/ai/actions/InsideCityCheckAction.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/actions/InsideCityCheckAction.java
@@ -1,0 +1,40 @@
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.ai.actions;
+
+import org.terasology.dynamicCities.settlements.SettlementEntityManager;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector2i;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
+
+@BehaviorAction(name = "inside_city_check")
+public class InsideCityCheckAction extends BaseAction {
+
+    @In
+    private transient SettlementEntityManager settlementEntityManager;
+
+    @Override
+    public void construct(Actor actor) {
+        settlementEntityManager = CoreRegistry.get(SettlementEntityManager.class);
+    }
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        LocationComponent locationComponent = actor.getComponent(LocationComponent.class);
+        Vector3f pos = locationComponent.getWorldPosition();
+
+        if (settlementEntityManager.checkOutsideAllSettlements(new Vector2i(pos.x, pos.z))) {
+            return BehaviorState.FAILURE;
+        }
+
+        return BehaviorState.SUCCESS;
+    }
+
+}

--- a/src/main/java/org/terasology/metalrenegades/combat/system/EnemySpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/combat/system/EnemySpawnSystem.java
@@ -128,7 +128,8 @@ public class EnemySpawnSystem extends BaseComponentSystem implements UpdateSubsc
 
             LocationComponent locComp = enemy.getComponent(LocationComponent.class);
             Vector3f enemyLoc = locComp.getWorldPosition();
-            if (settlementEntityManager.checkOutsideAllSettlements(new Vector2i(enemyLoc.getX(), enemyLoc.getZ())) && enemy.isActive()) {
+
+            if (enemy.isActive()) {
                 return false;
             }
             removeEnemy(enemy);
@@ -244,7 +245,7 @@ public class EnemySpawnSystem extends BaseComponentSystem implements UpdateSubsc
      * @param pos The position to spawn a character on top of.
      */
     private void spawnOnPosition(Vector3i pos) {
-        EntityBuilder entityBuilder = entityManager.newBuilder("MawGooey:mawGooey");
+        EntityBuilder entityBuilder = entityManager.newBuilder("MetalRenegades:enemyGooey");
         LocationComponent locationComponent = entityBuilder.getComponent(LocationComponent.class);
 
         locationComponent.setWorldPosition(pos.toVector3f());

--- a/src/main/java/org/terasology/metalrenegades/minimap/CharacterOverlay.java
+++ b/src/main/java/org/terasology/metalrenegades/minimap/CharacterOverlay.java
@@ -67,7 +67,7 @@ public class CharacterOverlay implements MinimapOverlay {
         this.map.put("MetalRenegades:scaredGooey", Assets.getTexture("MetalRenegades:scaredGooey"));
         this.map.put("MetalRenegades:angryGooey", Assets.getTexture("MetalRenegades:angryGooey"));
         this.map.put("MetalRenegades:friendlyGooey", Assets.getTexture("MetalRenegades:friendlyGooey"));
-        this.map.put("Mawgooey:mawgooey", Assets.getTexture("MetalRenegades:enemyIcon"));
+        this.map.put("MetalRenegades:enemyGooey", Assets.getTexture("MetalRenegades:enemyIcon"));
     }
 
     @Override


### PR DESCRIPTION
Previously, nighttime gooey enemies would simply disappear if they followed a character inside of a city. Now, the character's behavior itself has been changed to avoid players that enter cities. If a player encounters an enemy outside a city, the `hostile` behavior is used, but when the enemy enters a city, this changes to the `flee` behavior. This way, cities act as a sort of "save haven" for players.