### PR TITLE
feat: Replace SurfaceHeightFacet with SurfacesFacet and ElevationFacet

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/BaseFlatSurfaceProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/BaseFlatSurfaceProvider.java
@@ -21,9 +21,9 @@ import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Produces;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.facets.ElevationFacet;
 
-@Produces(SurfaceHeightFacet.class)
+@Produces(ElevationFacet.class)
 public class BaseFlatSurfaceProvider implements FacetProvider {
     @Override
     public void setSeed(long seed) {
@@ -32,8 +32,8 @@ public class BaseFlatSurfaceProvider implements FacetProvider {
     @Override
     public void process(GeneratingRegion region) {
         // Create our surface height facet (we will get into borders later)
-        Border3D border = region.getBorderForFacet(SurfaceHeightFacet.class);
-        SurfaceHeightFacet facet = new SurfaceHeightFacet(region.getRegion(), border);
+        Border3D border = region.getBorderForFacet(ElevationFacet.class);
+        ElevationFacet facet = new ElevationFacet(region.getRegion(), border);
 
         // Loop through every position in our 2d array
         Rect2i processRegion = facet.getWorldRegion();
@@ -42,6 +42,6 @@ public class BaseFlatSurfaceProvider implements FacetProvider {
         }
 
         // Pass our newly created and populated facet to the region
-        region.setRegionFacet(SurfaceHeightFacet.class, facet);
+        region.setRegionFacet(ElevationFacet.class, facet);
     }
 }

--- a/src/main/java/org/terasology/metalrenegades/world/BaseFlatWorldRasterizer.java
+++ b/src/main/java/org/terasology/metalrenegades/world/BaseFlatWorldRasterizer.java
@@ -23,7 +23,7 @@ import org.terasology.world.block.BlockManager;
 import org.terasology.world.chunks.CoreChunk;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.WorldRasterizer;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.facets.ElevationFacet;
 
 public class BaseFlatWorldRasterizer implements WorldRasterizer {
     private Block dirt;
@@ -35,9 +35,9 @@ public class BaseFlatWorldRasterizer implements WorldRasterizer {
 
     @Override
     public void generateChunk(CoreChunk chunk, Region chunkRegion) {
-        SurfaceHeightFacet surfaceHeightFacet = chunkRegion.getFacet(SurfaceHeightFacet.class);
+        ElevationFacet elevationFacet = chunkRegion.getFacet(ElevationFacet.class);
         for (Vector3i position : chunkRegion.getRegion()) {
-            float surfaceHeight = surfaceHeightFacet.getWorld(position.x, position.z);
+            float surfaceHeight = elevationFacet.getWorld(position.x, position.z);
             if (position.y < surfaceHeight) {
                 chunk.setBlock(ChunkMath.calcRelativeBlockPos(position), dirt);
             }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/SurfaceProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/SurfaceProvider.java
@@ -26,9 +26,9 @@ import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Produces;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.facets.ElevationFacet;
 
-@Produces(SurfaceHeightFacet.class)
+@Produces(ElevationFacet.class)
 public class SurfaceProvider implements FacetProvider {
     private Noise surfaceNoise;
 
@@ -39,15 +39,15 @@ public class SurfaceProvider implements FacetProvider {
 
     @Override
     public void process(GeneratingRegion region) {
-        Border3D border = region.getBorderForFacet(SurfaceHeightFacet.class);
-        SurfaceHeightFacet facet = new SurfaceHeightFacet(region.getRegion(), border);
+        Border3D border = region.getBorderForFacet(ElevationFacet.class);
+        ElevationFacet facet = new ElevationFacet(region.getRegion(), border);
 
         Rect2i processRegion = facet.getWorldRegion();
         for (BaseVector2i position: processRegion.contents()) {
             facet.setWorld(position, surfaceNoise.noise(position.x(), position.y()) * 3 + 10);
         }
 
-        region.setRegionFacet(SurfaceHeightFacet.class, facet);
+        region.setRegionFacet(ElevationFacet.class, facet);
     }
 
 }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
@@ -2,18 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.world.dynamic.discoverables;
 
-import org.terasology.math.TeraMath;
-import org.terasology.math.geom.Rect2i;
+import org.terasology.math.Region3i;
 import org.terasology.utilities.procedural.Noise;
 import org.terasology.utilities.procedural.WhiteNoise;
-import org.terasology.world.generation.*;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
+import org.terasology.world.generation.Border3D;
+import org.terasology.world.generation.Facet;
+import org.terasology.world.generation.FacetBorder;
+import org.terasology.world.generation.FacetProvider;
+import org.terasology.world.generation.GeneratingRegion;
+import org.terasology.world.generation.Produces;
+import org.terasology.world.generation.Requires;
+import org.terasology.world.generation.facets.SurfacesFacet;
 
 /**
  * Places chests into {@link DiscoverablesFacet} across the surface of the game world
  */
 @Produces(DiscoverablesFacet.class)
-@Requires(@Facet(value = SurfaceHeightFacet.class, border = @FacetBorder(bottom = 10, top = 10, sides = 10)))
+@Requires(@Facet(value = SurfacesFacet.class, border = @FacetBorder(bottom = 10, top = 10, sides = 10)))
 public class DiscoverablesProvider implements FacetProvider {
 
     /**
@@ -35,27 +40,25 @@ public class DiscoverablesProvider implements FacetProvider {
     public void process(GeneratingRegion region) {
         Border3D border = region.getBorderForFacet(DiscoverablesFacet.class).extendBy(10, 10, 10);
 
-        SurfaceHeightFacet surfaceHeightFacet = region.getRegionFacet(SurfaceHeightFacet.class);
+        SurfacesFacet surfacesFacet = region.getRegionFacet(SurfacesFacet.class);
         DiscoverablesFacet facet = new DiscoverablesFacet(region.getRegion(), border);
 
-        Rect2i worldRegion = surfaceHeightFacet.getWorldRegion();
+        Region3i worldRegion = surfacesFacet.getWorldRegion();
 
-        for (int wz = worldRegion.minY(); wz <= worldRegion.maxY(); wz++) {
-            for (int wx = worldRegion.minX(); wx <= worldRegion.maxX(); wx++) {
-                int surfaceHeight = TeraMath.floorToInt(surfaceHeightFacet.getWorld(wx, wz)) + 1;
+        for (int wx = worldRegion.minX(); wx <= worldRegion.maxX(); wx++) {
+            for (int wz = worldRegion.minZ(); wz <= worldRegion.maxZ(); wz++) {
+                for (int surfaceHeight : surfacesFacet.getWorldColumn(wx, wz)) {
+                    if (facet.getWorldRegion().encompasses(wx, surfaceHeight + 1, wz)) {
+                        if (noise.noise(wx, wz) < (CHEST_PROBABILITY * 2) - 1) {
+                            DiscoverableLocation.Type[] typeList = DiscoverableLocation.Type.values();
+                            int typeIndex = (int) (Math.abs(noise.noise(wx, surfaceHeight, wz)) * typeList.length);
+                            if (typeIndex > typeList.length) { // incredibly rare, but still possible with the noise range
+                                typeIndex = 0;
+                            }
 
-                if (surfaceHeight >= facet.getWorldRegion().minY() &&
-                    surfaceHeight <= facet.getWorldRegion().maxY() &&
-                    facet.getWorldRegion().encompasses(wx, surfaceHeight, wz)) {
-                    if (noise.noise(wx, wz) < (CHEST_PROBABILITY * 2) - 1) {
-                        DiscoverableLocation.Type[] typeList = DiscoverableLocation.Type.values();
-                        int typeIndex = (int) (Math.abs(noise.noise(wx, surfaceHeight, wz)) * typeList.length);
-                        if (typeIndex > typeList.length) { // incredibly rare, but still possible with the noise range
-                            typeIndex = 0;
+                            DiscoverableLocation.Type type = typeList[typeIndex];
+                            facet.setWorld(wx, surfaceHeight + 1, wz, new DiscoverableLocation(type));
                         }
-
-                        DiscoverableLocation.Type type = typeList[typeIndex];
-                        facet.setWorld(wx, surfaceHeight, wz, new DiscoverableLocation(type));
                     }
                 }
             }


### PR DESCRIPTION
Update for https://github.com/MovingBlocks/Terasology/pull/4237. This also depends on https://github.com/Terasology/DynamicCities/pull/70. Apparently the CoreWorld PR broke MetalRenegades, but this should fix that.

I haven't played MR much previously. The world looked approximately normal, but testing by someone who is more used to what the MR world usually looks like would be appreciated.