### PR TITLE
chore(minimap): reduce log noise from CharacterOverlay

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/minimap/CharacterOverlay.java
+++ b/src/main/java/org/terasology/metalrenegades/minimap/CharacterOverlay.java
@@ -16,72 +16,72 @@ import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.utilities.Assets;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
- * This class is used to add character overlays to the minimap based on the citizen type
- * and position
+ * This class is used to add character overlays to the minimap based on the citizen type and position
  */
 
 
 public class CharacterOverlay implements MinimapOverlay {
+    private static final Logger logger = LoggerFactory.getLogger(CharacterOverlay.class);
     private static final int ICON_SIZE = 16;
 
     private Vector2i iconSize = new Vector2i(ICON_SIZE, ICON_SIZE);
-
-    private Logger logger = LoggerFactory.getLogger(CharacterOverlay.class);
-
-    private ArrayList<EntityRef> Citizens;
-
-    private final Map<String, Optional> map = new HashMap<String, Optional>();
+    private ArrayList<EntityRef> citizens;
+    private final Map<String, Texture> overlays = new HashMap<>();
 
 
     /**
      * This constructor sets creates the list of citizens
      */
     public CharacterOverlay() {
-        this.Citizens = new ArrayList<EntityRef>();
-        this.map.put("MetalRenegades:marketCitizen", Assets.getTexture("MetalRenegades:marketGooey"));
-        this.map.put("MetalRenegades:badCitizen", Assets.getTexture("MetalRenegades:badCitizen"));
-        this.map.put("MetalRenegades:goodCitizen", Assets.getTexture("MetalRenegades:goodCitizen"));
-        this.map.put("MetalRenegades:gooeyCitizen", Assets.getTexture("MetalRenegades:gooeyCitizen"));
-        this.map.put("MetalRenegades:neutralGooey", Assets.getTexture("MetalRenegades:neutralGooey"));
-        this.map.put("MetalRenegades:nocturnalGooey", Assets.getTexture("MetalRenegades:nocturnalGooey"));
-        this.map.put("MetalRenegades:scaredGooey", Assets.getTexture("MetalRenegades:scaredGooey"));
-        this.map.put("MetalRenegades:angryGooey", Assets.getTexture("MetalRenegades:angryGooey"));
-        this.map.put("MetalRenegades:friendlyGooey", Assets.getTexture("MetalRenegades:friendlyGooey"));
-        this.map.put("MetalRenegades:enemyGooey", Assets.getTexture("MetalRenegades:enemyIcon"));
+        this.citizens = new ArrayList<EntityRef>();
+        registerOverlay("MetalRenegades:marketCitizen", () -> Assets.getTexture("MetalRenegades:marketGooey"));
+        registerOverlay("MetalRenegades:badCitizen", () -> Assets.getTexture("MetalRenegades:badCitizen"));
+        registerOverlay("MetalRenegades:goodCitizen", () -> Assets.getTexture("MetalRenegades:goodCitizen"));
+        registerOverlay("MetalRenegades:gooeyCitizen", () -> Assets.getTexture("MetalRenegades:gooeyCitizen"));
+        registerOverlay("MetalRenegades:neutralGooey", () -> Assets.getTexture("MetalRenegades:neutralGooey"));
+        registerOverlay("MetalRenegades:nocturnalGooey", () -> Assets.getTexture("MetalRenegades:nocturnalGooey"));
+        registerOverlay("MetalRenegades:scaredGooey", () -> Assets.getTexture("MetalRenegades:scaredGooey"));
+        registerOverlay("MetalRenegades:angryGooey", () -> Assets.getTexture("MetalRenegades:angryGooey"));
+        registerOverlay("MetalRenegades:friendlyGooey", () -> Assets.getTexture("MetalRenegades:friendlyGooey"));
+        registerOverlay("MetalRenegades:enemyGooey", () -> Assets.getTexture("MetalRenegades:enemyIcon"));
+    }
+
+    private void registerOverlay(final String citizenType, Supplier<Optional<Texture>> textureSupplier) {
+        Optional<Texture> texture = textureSupplier.get();
+        if (texture.isPresent()) {
+            overlays.put(citizenType, texture.get());
+        } else {
+            logger.warn("No icon found for citizen '{}'", citizenType);
+        }
     }
 
     @Override
     public void render(Canvas canvas, Rectanglei worldRect) {
-
-        Collection<EntityRef> citizens = this.Citizens;
-
         for (EntityRef entity : citizens) {
             LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
             if (locationComponent == null) {
-                logger.error("Cannot find location component for Citizen: ");
-                return;
+                logger.warn("Cannot render overlay for entity '{}' - missing LocationComponent", entity.getId());
+                continue;
             }
-
-            Vector2f location = new Vector2f(locationComponent.getLocalPosition().x(), locationComponent.getLocalPosition().z());
-            Vector2i mapPoint = RectUtility.map(worldRect, canvas.getRegion(), new Vector2i((int) location.x, (int) location.y), new Vector2i());
-            Vector2i iconCenter = new Vector2i((int) (mapPoint.x - (iconSize.x / 2.0f)), (int) (mapPoint.y - (iconSize.y / 2.0f)));
-
-            if (isInside(iconCenter, canvas.getRegion())) {
-                Rectanglei region = RectUtility.createFromMinAndSize((int) iconCenter.x, (int) iconCenter.y, (int) iconSize.x, (int) iconSize.y);
-                String citizenType = entity.getParentPrefab().getName();
-                if (this.map.get(citizenType) != null) {
-                    Optional<Texture> icon = this.map.get(citizenType);
-                    if (icon.isPresent()) {
-                        canvas.drawTexture(icon.get(), region);
-                    } else {
-                        logger.error("No icon found for citizen" + citizenType);
-                    }
+            String citizenType = entity.getParentPrefab().getName();
+            Optional<Texture> icon = Optional.ofNullable(overlays.get(citizenType));
+            if (icon.isPresent()) {
+                Vector2f location = new Vector2f(locationComponent.getLocalPosition().x(),
+                        locationComponent.getLocalPosition().z());
+                Vector2i mapPoint = RectUtility.map(worldRect, canvas.getRegion(), new Vector2i((int) location.x,
+                        (int) location.y), new Vector2i());
+                Vector2i iconCenter = new Vector2i((int) (mapPoint.x - (iconSize.x / 2.0f)),
+                        (int) (mapPoint.y - (iconSize.y / 2.0f)));
+                if (isInside(iconCenter, canvas.getRegion())) {
+                    Rectanglei region = RectUtility.createFromMinAndSize(iconCenter.x, iconCenter.y, iconSize.x,
+                            iconSize.y);
+                    canvas.drawTexture(icon.get(), region);
                 }
             }
         }
@@ -91,7 +91,7 @@ public class CharacterOverlay implements MinimapOverlay {
      * Checks if the citizen to be drawn lies inside the visible region in the minimap
      *
      * @param point: the coordinates of the point to be checked
-     * @param box:   limits
+     * @param box: limits
      * @return whether point is to be drawn or not
      */
     private boolean isInside(Vector2i point, Rectanglei box) {
@@ -106,7 +106,7 @@ public class CharacterOverlay implements MinimapOverlay {
      */
 
     public void addCitizen(EntityRef entityRef) {
-        this.Citizens.add(entityRef);
+        this.citizens.add(entityRef);
     }
 
     /**
@@ -116,7 +116,7 @@ public class CharacterOverlay implements MinimapOverlay {
      */
 
     public void removeCitizen(EntityRef entityRef) {
-        this.Citizens.remove(entityRef);
+        this.citizens.remove(entityRef);
 
     }
 


### PR DESCRIPTION
- chore: register and evaluate the overlay texture once during setup
- fix: only skip entities without location (don't abort rendering)
- perf?: check if icon is present first (no need to do math for those)
- chore: slightly improve logging messages

The following is only logged once when initializing the `CharacterOverly` now:
```
12:49:45.202 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:marketCitizen'
12:49:45.203 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:gooeyCitizen'
12:49:45.203 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:neutralGooey'
12:49:45.203 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:nocturnalGooey'
12:49:45.203 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:scaredGooey'
12:49:45.203 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:angryGooey'
12:49:45.203 [main] WARN  o.t.m.minimap.CharacterOverlay - No icon found for citizen 'MetalRenegades:friendlyGooey'
```

Related to #126 (reduces log spam, does _not_ fix missing icons).
Related to #111 (hard-coded asset references).
