### PR TITLE
feat: variable steepness of river banks

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
@@ -37,7 +37,7 @@ public class RiverProvider implements ScalableFacetProvider, ConfigurableFacetPr
         float[] noise = riverNoise.noise(facet.getWorldArea(), scale);
 
         float[] rivers = facet.getInternal();
-        float noiseMult = 50f / (configuration.riverWidth * configuration.riverDensity);
+        float noiseMult = 10f / (configuration.riverWidth * configuration.riverDensity);
         for (int i = 0; i < noise.length; ++i) {
             rivers[i] = -Math.min(0, Math.abs(noise[i]) * noiseMult - 1);
         }


### PR DESCRIPTION
The main outstanding problem with rivers was that they didn't look great when they happened to be placed in high mountains: the sides weren't steep enough to be canyons, but were too steep to look nice otherwise. In this PR, I added a noise function to determine steepness, so decent canyons sometimes form and sometimes it's more like a gentle river valley.

![steep](https://user-images.githubusercontent.com/13039463/121725077-660a3f80-caae-11eb-9cf9-7a3db004cf6f.png)
<p align=center><i>A mountainous area with high steepness, forming a canyon.</i></p>

![Screenshot from 2021-06-11 12-08-19](https://user-images.githubusercontent.com/13039463/121725084-686c9980-caae-11eb-81c5-e00b45856a5b.png)
<p align=center><i>A mountainous area with low steepness, where the terrain slowly and naturally slopes downward to the river.</i></p>

I think after this, rivers should be "good enough" - I'd still like to add dry riverbeds, but that can be done later, and change the humidity, but that will need to be done when I add new biomes anyway.