### PR TITLE
fix: animation reference for the enemyGooey prefab

### DIFF
--- a/assets/prefabs/characters/enemyGooey.prefab
+++ b/assets/prefabs/characters/enemyGooey.prefab
@@ -3,7 +3,7 @@
     "mesh": "Gooey:mawgooey",
     "heightOffset": -0.8,
     "material": "Gooey:mawgooeySkinGreen",
-    "animation": "Gooey:mawgooeyIdleFinal",
+    "animation": "Gooey:mawgooey#IdleFinal",
     "loop": true
   },
   "DropGrammar": {


### PR DESCRIPTION
### Contains

Animation fix for the `enemyGooey` prefab

### Objective

Fix the exception onserved when running MR: `18:08:47.214 [main] INFO  o.t.e.logic.behavior.core.ActionNode - Exception while running construct() of action org.terasology.behaviors.actions.SetAnimationAction@617ff808 from entity EntityRef{id = 12602, netId = 0, prefab = 'MetalRenegades:enemyGooey'}: bound must be positive`

### Changes

Fixed the animation reference syntax on `skeletalmesh:animation`