### PR TITLE
feat: basic biomes

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -22,6 +22,10 @@
             "minVersion": "1.1.0"
         },
         {
+            "id": "BiomesAPI",
+            "minVersion": "4.1.0"
+        },
+        {
             "id": "Cities",
             "minVersion": "1.1.0"
         },

--- a/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
@@ -10,6 +10,7 @@ import org.terasology.engine.entitySystem.Component;
 import org.terasology.engine.utilities.procedural.BrownianNoise;
 import org.terasology.engine.utilities.procedural.SimplexNoise;
 import org.terasology.engine.utilities.procedural.SubSampledNoise;
+import org.terasology.engine.utilities.procedural.WhiteNoise;
 import org.terasology.engine.world.generation.ConfigurableFacetProvider;
 import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.GeneratingRegion;
@@ -37,6 +38,7 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
     private SubSampledNoise mountainIntensityNoise;
     private SimplexHillsAndMountainsProviderConfiguration configuration =
             new SimplexHillsAndMountainsProviderConfiguration();
+    private WhiteNoise whiteNoise;
 
     @Override
     public void setSeed(long seed) {
@@ -49,6 +51,7 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
         mountainIntensityNoise = new SubSampledNoise(
                 new BrownianNoise(new SimplexNoise(seed + 5), 4),
                 new Vector2f(0.00005f, 0.00005f), 4);
+        whiteNoise = new WhiteNoise((int) (seed % Integer.MAX_VALUE) - 1);
     }
 
     @Override
@@ -71,7 +74,7 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
 
             heightData[i] = heightData[i] + 256 * densityMountains + 64 * densityHills;
             Vector2ic pos = positions.next();
-            if (densityMountains > 0.1) {
+            if (densityMountains > 0.1 + whiteNoise.noise(pos.x(), pos.y()) * 0.02) {
                 biomeData[i] = MRBiome.ROCKY;
             }
         }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
@@ -1,0 +1,53 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.world.dynamic;
+
+import org.joml.Vector2f;
+import org.terasology.biomesAPI.Biome;
+import org.terasology.core.world.CoreBiome;
+import org.terasology.core.world.generator.facets.BiomeFacet;
+import org.terasology.engine.utilities.procedural.BrownianNoise;
+import org.terasology.engine.utilities.procedural.SimplexNoise;
+import org.terasology.engine.utilities.procedural.SubSampledNoise;
+import org.terasology.engine.world.generation.Border3D;
+import org.terasology.engine.world.generation.FacetProvider;
+import org.terasology.engine.world.generation.GeneratingRegion;
+import org.terasology.engine.world.generation.Produces;
+
+/**
+ * The basic biome provider for Metal Renegades.
+ * Fills 65% of the world with desert, the rest with scrubland.
+ * Providers for features like rivers and mountains will adjust it further.
+ */
+@Produces(BiomeFacet.class)
+public class BaseBiomeProvider implements FacetProvider {
+
+    private SubSampledNoise biomeNoise;
+
+    @Override
+    public void setSeed(long seed) {
+        biomeNoise = new SubSampledNoise(
+                new BrownianNoise(new SimplexNoise(seed + 9), 5),
+                new Vector2f(0.0008f, 0.0008f), 4);
+    }
+
+    @Override
+    public void process(GeneratingRegion region) {
+        Border3D border = region.getBorderForFacet(BiomeFacet.class);
+        BiomeFacet biomes = new BiomeFacet(region.getRegion(), border);
+
+        float[] noiseData = biomeNoise.noise(biomes.getWorldArea());
+        Biome[] biomeData = biomes.getInternal();
+        for (int i = 0; i < biomeData.length; i++) {
+            // noiseData[i] goes from -1 to 1, so there's a 65% chance of desert
+            if (noiseData[i] > 0.3) {
+                biomeData[i] = MRBiome.SCRUBLAND;
+            } else {
+                biomeData[i] = CoreBiome.DESERT;
+            }
+        }
+
+        region.setRegionFacet(BiomeFacet.class, biomes);
+    }
+}

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
@@ -4,16 +4,20 @@
 package org.terasology.metalrenegades.world.dynamic;
 
 import org.joml.Vector2f;
+import org.joml.Vector2ic;
 import org.terasology.biomesAPI.Biome;
 import org.terasology.core.world.CoreBiome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
 import org.terasology.engine.utilities.procedural.BrownianNoise;
 import org.terasology.engine.utilities.procedural.SimplexNoise;
 import org.terasology.engine.utilities.procedural.SubSampledNoise;
+import org.terasology.engine.utilities.procedural.WhiteNoise;
 import org.terasology.engine.world.generation.Border3D;
 import org.terasology.engine.world.generation.FacetProvider;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
+
+import java.util.Iterator;
 
 /**
  * The basic biome provider for Metal Renegades.
@@ -24,12 +28,14 @@ import org.terasology.engine.world.generation.Produces;
 public class BaseBiomeProvider implements FacetProvider {
 
     private SubSampledNoise biomeNoise;
+    private WhiteNoise whiteNoise;
 
     @Override
     public void setSeed(long seed) {
         biomeNoise = new SubSampledNoise(
                 new BrownianNoise(new SimplexNoise(seed + 9), 5),
                 new Vector2f(0.0008f, 0.0008f), 4);
+        whiteNoise = new WhiteNoise((int) (seed % Integer.MAX_VALUE) - 2);
     }
 
     @Override
@@ -39,9 +45,11 @@ public class BaseBiomeProvider implements FacetProvider {
 
         float[] noiseData = biomeNoise.noise(biomes.getWorldArea());
         Biome[] biomeData = biomes.getInternal();
+        Iterator<Vector2ic> positions = biomes.getWorldArea().iterator();
         for (int i = 0; i < biomeData.length; i++) {
+            Vector2ic pos = positions.next();
             // noiseData[i] goes from -1 to 1, so there's a 65% chance of desert
-            if (noiseData[i] > 0.3) {
+            if (noiseData[i] > 0.3 + whiteNoise.noise(pos.x(), pos.y()) * 0.03) {
                 biomeData[i] = MRBiome.SCRUBLAND;
             } else {
                 biomeData[i] = CoreBiome.DESERT;

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/DynamicWorldGenerator.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/DynamicWorldGenerator.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.world.dynamic;
 
-import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexRoughnessProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
@@ -52,7 +51,7 @@ public class DynamicWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new RiverToElevationProvider())
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new SimplexRoughnessProvider())
-                .addProvider(new DefaultFloraProvider())
+                .addProvider(new FloraProvider())
                 .addProvider(new DefaultTreeProvider())
                 .addProvider(new ResourceProvider())
                 .addProvider(new RoughnessProvider())

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/DynamicWorldGenerator.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/DynamicWorldGenerator.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.world.dynamic;
 
-import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexRoughnessProvider;
@@ -47,12 +46,12 @@ public class DynamicWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new SurfaceProvider())
                 .addProvider(new HumidityProvider())
                 .addProvider(new TemperatureProvider())
+                .addProvider(new BaseBiomeProvider())
                 .addProvider(new RiverProvider())
                 .addProvider(new SimplexHillsAndMountainsProvider())
                 .addProvider(new RiverToElevationProvider())
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new SimplexRoughnessProvider())
-                .addProvider(new BiomeProvider())
                 .addProvider(new DefaultFloraProvider())
                 .addProvider(new DefaultTreeProvider())
                 .addProvider(new ResourceProvider())

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/FloraProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/FloraProvider.java
@@ -1,0 +1,124 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.world.dynamic;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.joml.Vector3i;
+import org.terasology.biomesAPI.Biome;
+import org.terasology.core.world.CoreBiome;
+import org.terasology.core.world.generator.facetProviders.PositionFilters;
+import org.terasology.core.world.generator.facetProviders.SurfaceObjectProvider;
+import org.terasology.core.world.generator.facets.BiomeFacet;
+import org.terasology.core.world.generator.facets.FloraFacet;
+import org.terasology.core.world.generator.rasterizers.FloraType;
+import org.terasology.engine.entitySystem.Component;
+import org.terasology.engine.utilities.procedural.Noise;
+import org.terasology.engine.utilities.procedural.WhiteNoise;
+import org.terasology.engine.world.generation.ConfigurableFacetProvider;
+import org.terasology.engine.world.generation.Facet;
+import org.terasology.engine.world.generation.FacetBorder;
+import org.terasology.engine.world.generation.GeneratingRegion;
+import org.terasology.engine.world.generation.Produces;
+import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.facets.SeaLevelFacet;
+import org.terasology.engine.world.generation.facets.SurfacesFacet;
+import org.terasology.nui.properties.Range;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * For the most part, this is just a copy of DefaultFloraProvider from CoreWorlds, extended with the new biomes.
+ */
+@Produces(FloraFacet.class)
+@Requires({
+        @Facet(SeaLevelFacet.class),
+        @Facet(value = SurfacesFacet.class, border = @FacetBorder(bottom = 1)),
+        @Facet(BiomeFacet.class)
+})
+public class FloraProvider extends SurfaceObjectProvider<Biome, FloraType> implements ConfigurableFacetProvider {
+    private Noise densityNoiseGen;
+
+    private Configuration configuration = new Configuration();
+
+    private Map<FloraType, Float> typeProbs = ImmutableMap.of(
+            FloraType.GRASS, 0.85f,
+            FloraType.FLOWER, 0.1f,
+            FloraType.MUSHROOM, 0.05f);
+
+    private Map<Biome, Float> biomeProbs = ImmutableMap.<Biome, Float>builder()
+            .put(MRBiome.RIVER, 0.2f)
+            .put(MRBiome.STEPPE, 0.1f)
+            .put(MRBiome.ROCKY, 0.001f)
+            .put(MRBiome.SCRUBLAND, 0.05f)
+            .put(CoreBiome.DESERT, 0.001f).build();
+
+    public FloraProvider() {
+        Biome[] biomes = {MRBiome.RIVER, MRBiome.STEPPE, MRBiome.SCRUBLAND, MRBiome.ROCKY, CoreBiome.DESERT};
+
+        for (Biome biome : biomes) {
+            float biomeProb = biomeProbs.get(biome);
+            for (FloraType type : typeProbs.keySet()) {
+                float typeProb = typeProbs.get(type);
+                float prob = biomeProb * typeProb;
+                register(biome, type, prob);
+            }
+        }
+
+        register(CoreBiome.DESERT, FloraType.MUSHROOM, 0);
+    }
+
+    @Override
+    public void setSeed(long seed) {
+        super.setSeed(seed);
+
+        densityNoiseGen = new WhiteNoise(seed);
+    }
+
+    @Override
+    public void process(GeneratingRegion region) {
+        SurfacesFacet surfaces = region.getRegionFacet(SurfacesFacet.class);
+        BiomeFacet biomeFacet = region.getRegionFacet(BiomeFacet.class);
+
+        FloraFacet facet = new FloraFacet(region.getRegion(), region.getBorderForFacet(FloraFacet.class));
+
+        List<Predicate<Vector3i>> filters = getFilters(region);
+        populateFacet(facet, surfaces, biomeFacet, filters);
+
+        region.setRegionFacet(FloraFacet.class, facet);
+    }
+
+    protected List<Predicate<Vector3i>> getFilters(GeneratingRegion region) {
+        List<Predicate<Vector3i>> filters = Lists.newArrayList();
+
+        SeaLevelFacet seaLevel = region.getRegionFacet(SeaLevelFacet.class);
+        filters.add(PositionFilters.minHeight(seaLevel.getSeaLevel()));
+
+        filters.add(PositionFilters.probability(densityNoiseGen, configuration.density));
+
+        return filters;
+    }
+
+    @Override
+    public String getConfigurationName() {
+        return "Flora";
+    }
+
+    @Override
+    public Component getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void setConfiguration(Component configuration) {
+        this.configuration = (Configuration) configuration;
+    }
+
+    public static class Configuration implements Component {
+        @Range(min = 0, max = 1.0f, increment = 0.05f, precision = 2, description = "Define the overall flora density")
+        public float density = 0.4f;
+    }
+}

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
@@ -1,0 +1,94 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.world.dynamic;
+
+import org.joml.Vector3ic;
+import org.terasology.biomesAPI.Biome;
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.world.block.Block;
+import org.terasology.engine.world.block.BlockManager;
+import org.terasology.gestalt.naming.Name;
+
+/**
+ * The new biomes added by Metal Renegades.
+ * On top of these, MR reuses CoreBiome.DESERT.
+ */
+public enum MRBiome implements Biome {
+    ROCKY("Rocky"),
+    SCRUBLAND("Scrubland"),
+    RIVER("Riparian"),
+    STEPPE("Steppe");
+
+    private final Name id;
+    private final String displayName;
+
+    private Block stone;
+    private Block sand;
+    private Block grass;
+    private Block snow;
+    private Block dirt;
+
+    MRBiome(String displayName) {
+        this.id = new Name("MetalRenegades:" + name());
+        this.displayName = displayName;
+
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        stone = blockManager.getBlock("CoreAssets:stone");
+        sand = blockManager.getBlock("CoreAssets:Sand");
+        grass = blockManager.getBlock("CoreAssets:Grass");
+        snow = blockManager.getBlock("CoreAssets:Snow");
+        dirt = blockManager.getBlock("CoreAssets:Dirt");
+    }
+
+    @Override
+    public Block getSurfaceBlock(Vector3ic pos, int seaLevel) {
+        int height = pos.y() - seaLevel;
+        switch (this) {
+            case ROCKY:
+                return stone;
+            case SCRUBLAND:
+                return dirt;
+            case RIVER:
+                if (pos.y() <= seaLevel) {
+                    // Don't put grass under water
+                    return sand;
+                } else {
+                    return grass;
+                }
+            case STEPPE:
+                return grass;
+            default:
+                return dirt;
+        }
+    }
+
+    @Override
+    public Block getBelowSurfaceBlock(Vector3ic pos, float density) {
+        switch (this) {
+            case ROCKY:
+                return stone;
+            default:
+                if (density > 8) {
+                    return stone;
+                } else {
+                    return dirt;
+                }
+        }
+    }
+
+    @Override
+    public Name getId() {
+        return id;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return this.displayName;
+    }
+
+    @Override
+    public String toString() {
+        return this.displayName;
+    }
+}

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
@@ -43,14 +43,13 @@ public enum MRBiome implements Biome {
 
     @Override
     public Block getSurfaceBlock(Vector3ic pos, int seaLevel) {
-        int height = pos.y() - seaLevel;
         switch (this) {
             case ROCKY:
                 return stone;
             case SCRUBLAND:
                 return dirt;
             case RIVER:
-                if (pos.y() <= seaLevel) {
+                if (pos.y() < seaLevel) {
                     // Don't put grass under water
                     return sand;
                 } else {

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiomes.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiomes.java
@@ -1,0 +1,28 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.metalrenegades.world.dynamic;
+
+import org.terasology.biomesAPI.BiomeRegistry;
+import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
+import org.terasology.engine.entitySystem.systems.RegisterSystem;
+import org.terasology.engine.registry.In;
+
+import java.util.stream.Stream;
+
+/**
+ * Registers the biomes added by Metal Renegades.
+ */
+@RegisterSystem
+public class MRBiomes extends BaseComponentSystem {
+    @In
+    private BiomeRegistry biomeRegistry;
+
+    /**
+     * Registration of systems must be done in preBegin to be early enough.
+     */
+    @Override
+    public void preBegin() {
+        Stream.of(MRBiome.values()).forEach(biomeRegistry::registerBiome);
+    }
+}

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -4,12 +4,14 @@
 package org.terasology.metalrenegades.world.rivers;
 
 import org.joml.Vector2f;
+import org.joml.Vector2ic;
 import org.terasology.biomesAPI.Biome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
 import org.terasology.engine.entitySystem.Component;
 import org.terasology.engine.utilities.procedural.BrownianNoise;
 import org.terasology.engine.utilities.procedural.SimplexNoise;
 import org.terasology.engine.utilities.procedural.SubSampledNoise;
+import org.terasology.engine.utilities.procedural.WhiteNoise;
 import org.terasology.engine.world.generation.ConfigurableFacetProvider;
 import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.GeneratingRegion;
@@ -21,6 +23,8 @@ import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
 import org.terasology.math.TeraMath;
 import org.terasology.metalrenegades.world.dynamic.MRBiome;
 
+import java.util.Iterator;
+
 
 @Requires({@Facet(RiverFacet.class), @Facet(SeaLevelFacet.class)})
 @Updates({@Facet(ElevationFacet.class), @Facet(SurfaceHumidityFacet.class), @Facet(BiomeFacet.class)})
@@ -29,12 +33,16 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
 
     private Configuration configuration = new Configuration();
     private SubSampledNoise steepnessNoise;
+    private WhiteNoise whiteNoiseHeight;
+    private WhiteNoise whiteNoiseRiver;
 
     @Override
     public void setSeed(long seed) {
         steepnessNoise = new SubSampledNoise(
                 new BrownianNoise(new SimplexNoise(seed + 7), 3),
                 new Vector2f(0.0008f, 0.0008f), SAMPLE_RATE);
+        whiteNoiseHeight = new WhiteNoise((int) (seed % Integer.MAX_VALUE));
+        whiteNoiseRiver = new WhiteNoise((int) (seed % Integer.MAX_VALUE) - 4);
     }
 
     @Override
@@ -50,6 +58,7 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
         float[] humidityData = humidity.getInternal();
         float[] steepnessData = steepnessNoise.noise(elevation.getWorldArea());
         Biome[] biomeData = biomes.getInternal();
+        Iterator<Vector2ic> positions = elevation.getWorldArea().iterator();
         for (int i = 0; i < surfaceHeights.length; ++i) {
             float steepness = steepnessData[i];
             float riverFac = TeraMath.clamp(riversData[i]);
@@ -63,7 +72,10 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
                 surfaceHeights[i] = TeraMath.lerp(surfaceHeights[i], riverBedElevation, riverFac);
             }
             humidityData[i] += Math.max(0, 0.2 * (seaLevel - surfaceHeights[i] + 10) * riversData[i]);
-            if (surfaceHeights[i] < seaLevel + 15 && riversData[i] > 0.72) {
+
+            Vector2ic pos = positions.next();
+            if (surfaceHeights[i] < seaLevel + 8f + whiteNoiseHeight.noise(pos.x(), pos.y()) * 2
+                    && riversData[i] > 0.7 + whiteNoiseRiver.noise(pos.x(), pos.y()) * 0.04) {
                 biomeData[i] = MRBiome.RIVER;
             }
         }

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -4,6 +4,8 @@
 package org.terasology.metalrenegades.world.rivers;
 
 import org.joml.Vector2f;
+import org.terasology.biomesAPI.Biome;
+import org.terasology.core.world.generator.facets.BiomeFacet;
 import org.terasology.engine.entitySystem.Component;
 import org.terasology.engine.utilities.procedural.BrownianNoise;
 import org.terasology.engine.utilities.procedural.SimplexNoise;
@@ -17,10 +19,11 @@ import org.terasology.engine.world.generation.facets.ElevationFacet;
 import org.terasology.engine.world.generation.facets.SeaLevelFacet;
 import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
 import org.terasology.math.TeraMath;
+import org.terasology.metalrenegades.world.dynamic.MRBiome;
 
 
 @Requires({@Facet(RiverFacet.class), @Facet(SeaLevelFacet.class)})
-@Updates({@Facet(ElevationFacet.class), @Facet(SurfaceHumidityFacet.class)})
+@Updates({@Facet(ElevationFacet.class), @Facet(SurfaceHumidityFacet.class), @Facet(BiomeFacet.class)})
 public class RiverToElevationProvider implements ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 
@@ -39,12 +42,14 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
         RiverFacet rivers = region.getRegionFacet(RiverFacet.class);
         ElevationFacet elevation = region.getRegionFacet(ElevationFacet.class);
         SurfaceHumidityFacet humidity = region.getRegionFacet(SurfaceHumidityFacet.class);
+        BiomeFacet biomes = region.getRegionFacet(BiomeFacet.class);
         int seaLevel = region.getRegionFacet(SeaLevelFacet.class).getSeaLevel();
 
         float[] surfaceHeights = elevation.getInternal();
         float[] riversData = rivers.getInternal();
         float[] humidityData = humidity.getInternal();
         float[] steepnessData = steepnessNoise.noise(elevation.getWorldArea());
+        Biome[] biomeData = biomes.getInternal();
         for (int i = 0; i < surfaceHeights.length; ++i) {
             float steepness = steepnessData[i];
             float riverFac = TeraMath.clamp(riversData[i]);
@@ -58,6 +63,9 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
                 surfaceHeights[i] = TeraMath.lerp(surfaceHeights[i], riverBedElevation, riverFac);
             }
             humidityData[i] += Math.max(0, 0.2 * (seaLevel - surfaceHeights[i] + 10) * riversData[i]);
+            if (surfaceHeights[i] < seaLevel + 15 && riversData[i] > 0.72) {
+                biomeData[i] = MRBiome.RIVER;
+            }
         }
     }
 


### PR DESCRIPTION
This PR introduces four new biomes, which are provided in stages. First the `BaseBiomeProvider` fills the world with desert and scrubland, then the `RiverToElevationProvider` and `SimplexHillsAndMountainsProvider` add river and rocky biomes respectively based on those terrain features. The steppe biome isn't currently generated, but will be generated in high-altitude flat areas, like the tops of mesas when those are added; it will also have trees, which will be added then as well.