### PR TITLE
fix: stop discoverables and the player from spawning underwater

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/DynamicWorldGenerator.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/DynamicWorldGenerator.java
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.world.dynamic;
 
+import org.joml.Vector2i;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.core.world.generator.facetProviders.SimplexRoughnessProvider;
+import org.terasology.core.world.generator.facetProviders.SpawnPlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.dynamicCities.region.RegionEntityProvider;
@@ -58,6 +60,7 @@ public class DynamicWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new DiscoverablesProvider())
                 .addProvider(new SiteFacetProvider())
                 .addProvider(new SettlementFacetProvider())
+                .addProvider(new SpawnPlateauProvider(new Vector2i(0, 0)))
                 .addEntities(new RegionEntityProvider())
                 .addRasterizer(new SolidRasterizer())
                 .addRasterizer(new FloraRasterizer())

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/discoverables/DiscoverablesProvider.java
@@ -12,13 +12,17 @@ import org.terasology.engine.world.generation.FacetProvider;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
 import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.facets.SeaLevelFacet;
 import org.terasology.engine.world.generation.facets.SurfacesFacet;
 
 /**
  * Places chests into {@link DiscoverablesFacet} across the surface of the game world
  */
 @Produces(DiscoverablesFacet.class)
-@Requires(@Facet(value = SurfacesFacet.class, border = @FacetBorder(bottom = 10, top = 10, sides = 10)))
+@Requires({
+        @Facet(value = SurfacesFacet.class, border = @FacetBorder(bottom = 10, top = 10, sides = 10)),
+        @Facet(SeaLevelFacet.class)
+})
 public class DiscoverablesProvider implements FacetProvider {
 
     /**
@@ -40,6 +44,8 @@ public class DiscoverablesProvider implements FacetProvider {
     public void process(GeneratingRegion region) {
         Border3D border = region.getBorderForFacet(DiscoverablesFacet.class).extendBy(10, 10, 10);
 
+        SeaLevelFacet seaLevelFacet = region.getRegionFacet(SeaLevelFacet.class);
+        int seaLevel = seaLevelFacet.getSeaLevel();
         SurfacesFacet surfacesFacet = region.getRegionFacet(SurfacesFacet.class);
         DiscoverablesFacet facet = new DiscoverablesFacet(region.getRegion(), border);
 
@@ -48,7 +54,7 @@ public class DiscoverablesProvider implements FacetProvider {
         for (int wx = worldRegion.minX(); wx <= worldRegion.maxX(); wx++) {
             for (int wz = worldRegion.minZ(); wz <= worldRegion.maxZ(); wz++) {
                 for (int surfaceHeight : surfacesFacet.getWorldColumn(wx, wz)) {
-                    if (facet.getWorldRegion().contains(wx, surfaceHeight + 1, wz)) {
+                    if (surfaceHeight >= seaLevel && facet.getWorldRegion().contains(wx, surfaceHeight + 1, wz)) {
                         if (noise.noise(wx, wz) < (CHEST_PROBABILITY * 2) - 1) {
                             DiscoverableLocation.Type[] typeList = DiscoverableLocation.Type.values();
                             int typeIndex = (int) (Math.abs(noise.noise(wx, surfaceHeight, wz)) * typeList.length);


### PR DESCRIPTION
This PR makes discoverables skip spawn locations below sea level, and adds the SpawnPlateau from CoreWorlds to keep the player from spawning underwater. Both were already much rarer with https://github.com/Terasology/MetalRenegades/pull/151, since it makes rivers much smaller, but still possible, so this actually fixes the problems.