### PR TITLE
feat: variable-size mesas based on noise

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
@@ -59,7 +59,7 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
                 new Vector2f(0.00005f, 0.00005f), 4);
         mesaNoise = new SubSampledNoise(
                 new BrownianNoise(new SimplexNoise(seed + 14), 6),
-                new Vector2f(0.001f, 0.001f), 4);
+                new Vector2f(0.002f, 0.002f), 4);
         mesaHeightNoise = new SubSampledNoise(
                 new BrownianNoise(new SimplexNoise(seed + 15), 3),
                 new Vector2f(0.0002f, 0.0002f), 4);
@@ -84,14 +84,14 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
         Iterator<Vector2ic> positions = facet.getWorldArea().iterator();
         for (int i = 0; i < heightData.length; ++i) {
             // Only place mesas at humidity below humidMax, since they only occur in dry areas like deserts
-            float humidMax = 0.18f;
-            float humidSteepness = 10;
+            float humidMax = 0.17f;
+            float humidSteepness = 5;
             float baseMesaNoise =
-                    mesaData[i] * TeraMath.fadePerlin(TeraMath.clamp(humidSteepness - humidSteepness / humidMax * humidityData[i]));
+                    mesaData[i] * TeraMath.fadePerlin(TeraMath.clamp(humidSteepness * (1 - humidityData[i] / humidMax)));
             // Noise values between threshold and threshold+smoothness are on the side of a mesa
             // Noise values smaller than threshold are nothing, and larger than threshold+smoothness are on a steppe
             // Like rivers, a graph is available to see the details: https://www.desmos.com/calculator/dc04yalbds
-            float threshold = 0.5f;
+            float threshold = 1.1f - 0.2f * configuration.mesaDensity;
             float smoothness = 0.05f;
             float mesaH = TeraMath.fadePerlin(TeraMath.clamp((baseMesaNoise - threshold) / smoothness));
             // Create a slope up to the bottom of the mesa
@@ -141,5 +141,8 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
 
         @Range(min = 0, max = 2f, increment = 0.01f, precision = 2, description = "Hill Amplitude")
         public float hillAmplitude = 1f;
+
+        @Range(min = 0, max = 10f, increment = 0.01f, precision = 2, description = "Mesa density")
+        public float mesaDensity = 4f;
     }
 }

--- a/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
@@ -106,8 +106,7 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
                     Math.max(hillData[i] * 2.12f - 0.1f, 0) * (1.0f - mountainIntensity) * configuration.hillAmplitude;
 
             heightData[i] = heightData[i]
-                    // Get rid of mountains and hills around mesas, so they don't interfere
-                    + (256 * densityMountains + 64 * densityHills) * TeraMath.clamp(2 - 3 * baseMesaNoise)
+                    + 256 * densityMountains + 64 * densityHills
                     + (64 + 32 * mesaHeightData[i]) * mesa;
             Vector2ic pos = positions.next();
             if (Math.max(mesa, densityMountains) > 0.1 + whiteNoise.noise(pos.x(), pos.y()) * 0.02) {

--- a/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
@@ -81,8 +81,13 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
             // Noise values between threshold and threshold+smoothness are on the side of a mesa
             // Noise values smaller than threshold are nothing, and larger than threshold+smoothness are on a steppe
             float threshold = 0.5f;
-            float smoothness = 0.02f;
-            float mesa = TeraMath.fadeHermite(TeraMath.clamp((mesaData[i] - threshold) / smoothness));
+            float smoothness = 0.05f;
+            float mesaH = TeraMath.fadePerlin(TeraMath.clamp((mesaData[i] - threshold) / smoothness));
+            // Create a slope up to the bottom of the mesa
+            float slopeSteepness = 5;
+            float slopeHeight = 0.7f; // values from 0.5 - 1.5 look fine, might be noise later
+            float mesaL = TeraMath.clamp(slopeSteepness * (mesaData[i] - threshold - 0.5f * smoothness) + 1);
+            float mesa = (mesaH + slopeHeight * mesaL) / (1 + slopeHeight);
 
             float mountainIntensity = mountainIntensityData[i] * 0.5f + 0.5f;
             float densityMountains = Math.max(mountainData[i] * 2.12f, 0) * mountainIntensity * configuration.mountainAmplitude;

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
@@ -14,7 +14,9 @@ import org.terasology.engine.world.generation.FacetProvider;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
 import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.Updates;
 import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
+import org.terasology.metalrenegades.world.rivers.RiverFacet;
 
 import java.util.Iterator;
 
@@ -52,7 +54,7 @@ public class BaseBiomeProvider implements FacetProvider {
         for (int i = 0; i < biomeData.length; i++) {
             Vector2ic pos = positions.next();
             // humidity goes from 0 to 0.3, so there's a 2/3 chance of desert
-            if (humidityData[i] > 0.2 + whiteNoise.noise(pos.x(), pos.y()) * 0.03) {
+            if (humidityData[i] > 0.2 + whiteNoise.noise(pos.x(), pos.y()) * 0.01) {
                 biomeData[i] = MRBiome.SCRUBLAND;
             } else {
                 biomeData[i] = CoreBiome.DESERT;

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
@@ -3,38 +3,34 @@
 
 package org.terasology.metalrenegades.world.dynamic;
 
-import org.joml.Vector2f;
 import org.joml.Vector2ic;
 import org.terasology.biomesAPI.Biome;
 import org.terasology.core.world.CoreBiome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
-import org.terasology.engine.utilities.procedural.BrownianNoise;
-import org.terasology.engine.utilities.procedural.SimplexNoise;
-import org.terasology.engine.utilities.procedural.SubSampledNoise;
 import org.terasology.engine.utilities.procedural.WhiteNoise;
 import org.terasology.engine.world.generation.Border3D;
+import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.FacetProvider;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
+import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
 
 import java.util.Iterator;
 
 /**
  * The basic biome provider for Metal Renegades.
- * Fills 65% of the world with desert, the rest with scrubland.
+ * Fills 2/3 of the world with desert, the rest with scrubland, based on the humidity.
  * Providers for features like rivers and mountains will adjust it further.
  */
 @Produces(BiomeFacet.class)
+@Requires(@Facet(SurfaceHumidityFacet.class))
 public class BaseBiomeProvider implements FacetProvider {
 
-    private SubSampledNoise biomeNoise;
     private WhiteNoise whiteNoise;
 
     @Override
     public void setSeed(long seed) {
-        biomeNoise = new SubSampledNoise(
-                new BrownianNoise(new SimplexNoise(seed + 9), 5),
-                new Vector2f(0.0008f, 0.0008f), 4);
         whiteNoise = new WhiteNoise((int) (seed % Integer.MAX_VALUE) - 2);
 
         // Give the seed to the biomes - this is essentially mutable global state, and only works because there's only one world at a time
@@ -48,14 +44,15 @@ public class BaseBiomeProvider implements FacetProvider {
     public void process(GeneratingRegion region) {
         Border3D border = region.getBorderForFacet(BiomeFacet.class);
         BiomeFacet biomes = new BiomeFacet(region.getRegion(), border);
+        SurfaceHumidityFacet humidityFacet = region.getRegionFacet(SurfaceHumidityFacet.class);
 
-        float[] noiseData = biomeNoise.noise(biomes.getWorldArea());
+        float[] humidityData = humidityFacet.getInternal();
         Biome[] biomeData = biomes.getInternal();
         Iterator<Vector2ic> positions = biomes.getWorldArea().iterator();
         for (int i = 0; i < biomeData.length; i++) {
             Vector2ic pos = positions.next();
-            // noiseData[i] goes from -1 to 1, so there's a 65% chance of desert
-            if (noiseData[i] > 0.3 + whiteNoise.noise(pos.x(), pos.y()) * 0.03) {
+            // humidity goes from 0 to 0.3, so there's a 2/3 chance of desert
+            if (humidityData[i] > 0.2 + whiteNoise.noise(pos.x(), pos.y()) * 0.03) {
                 biomeData[i] = MRBiome.SCRUBLAND;
             } else {
                 biomeData[i] = CoreBiome.DESERT;

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/HumidityProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/HumidityProvider.java
@@ -6,7 +6,7 @@ import org.joml.Vector2f;
 import org.joml.Vector2ic;
 import org.terasology.engine.entitySystem.Component;
 import org.terasology.engine.utilities.procedural.BrownianNoise;
-import org.terasology.engine.utilities.procedural.PerlinNoise;
+import org.terasology.engine.utilities.procedural.SimplexNoise;
 import org.terasology.engine.utilities.procedural.SubSampledNoise;
 import org.terasology.engine.world.generation.Border3D;
 import org.terasology.engine.world.generation.ConfigurableFacetProvider;
@@ -48,10 +48,11 @@ public class HumidityProvider implements ConfigurableFacetProvider {
         Border3D border = region.getBorderForFacet(SurfaceHumidityFacet.class);
         SurfaceHumidityFacet facet = new SurfaceHumidityFacet(region.getRegion(), border);
 
-        // TODO: Setup humidity
-        for (Vector2ic position: facet.getWorldArea()) {
-            double hum = getRandomHumidity(position);
-            facet.setWorld(position, (float) hum);
+        float[] humidityData = facet.getInternal();
+        float[] noiseData = noise.noise(facet.getWorldArea());
+        for (int i = 0; i < humidityData.length; i++) {
+            // The base humidity level goes from 0 to 0.3
+            humidityData[i] = (noiseData[i] * 0.5f + 0.5f) * 0.3f;
         }
 
         region.setRegionFacet(SurfaceHumidityFacet.class, facet);
@@ -79,7 +80,7 @@ public class HumidityProvider implements ConfigurableFacetProvider {
     private void reload() {
         float realScale = config.scale * 0.01f;
         Vector2f scale = new Vector2f(realScale, realScale);
-        BrownianNoise brown = new BrownianNoise(new PerlinNoise(seed + 6), config.octaves);
+        BrownianNoise brown = new BrownianNoise(new SimplexNoise(seed + 6), config.octaves);
         noise = new SubSampledNoise(brown, scale, SAMPLE_RATE);
     }
 
@@ -88,10 +89,10 @@ public class HumidityProvider implements ConfigurableFacetProvider {
     }
 
     public static class Configuration implements Component {
-        @Range(min = 0, max = 10.0f, increment = 1f, precision = 0, description = "The number of noise octaves")
-        public int octaves = 8;
+        @Range(min = 0, max = 10, increment = 1, precision = 0, description = "The number of noise octaves")
+        public int octaves = 5;
 
         @Range(min = 0.01f, max = 5f, increment = 0.01f, precision = 2, description = "The noise scale")
-        public float scale = 0.05f;
+        public float scale = 0.08f;
     }
 }

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
@@ -104,9 +104,16 @@ public enum MRBiome implements Biome {
         switch (this) {
             case ROCKY:
                 return getStratum(pos);
+            case STEPPE:
+                // The steppe has less dirt since it's often visible on the side of mesas
+                if (density > 2) {
+                    return getStratum(pos);
+                } else {
+                    return dirt;
+                }
             default:
                 if (density > 8) {
-                    return stone;
+                    return getStratum(pos);
                 } else {
                     return dirt;
                 }

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
@@ -67,7 +67,7 @@ public class RiverProvider implements ScalableFacetProvider, ConfigurableFacetPr
         public float riverWidth = 10;
 
         @Range(label = "River density", min = 0, max = 4f, increment = 0.1f, precision = 1)
-        public float riverDensity = 0.5f;
+        public float riverDensity = 0.2f;
 
         @Range(label = "River depth", min = 0, max = 64f, increment = 1f, precision = 0, description = "Maximum river Depth")
         public float maxDepth = 16;

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
@@ -9,12 +9,16 @@ import org.terasology.engine.utilities.procedural.BrownianNoise;
 import org.terasology.engine.utilities.procedural.SimplexNoise;
 import org.terasology.engine.utilities.procedural.SubSampledNoise;
 import org.terasology.engine.world.generation.ConfigurableFacetProvider;
+import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
 import org.terasology.engine.world.generation.ScalableFacetProvider;
+import org.terasology.engine.world.generation.Updates;
+import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
 import org.terasology.nui.properties.Range;
 
 @Produces(RiverFacet.class)
+@Updates(@Facet(SurfaceHumidityFacet.class))
 public class RiverProvider implements ScalableFacetProvider, ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 
@@ -34,12 +38,15 @@ public class RiverProvider implements ScalableFacetProvider, ConfigurableFacetPr
     public void process(GeneratingRegion region, float scale) {
         RiverFacet facet = new RiverFacet(region.getRegion(), region.getBorderForFacet(RiverFacet.class),
                 configuration.maxDepth);
-        float[] noise = riverNoise.noise(facet.getWorldArea(), scale);
+        SurfaceHumidityFacet humidityFacet = region.getRegionFacet(SurfaceHumidityFacet.class);
 
+        float[] humidity = humidityFacet.getInternal();
+        float[] noise = riverNoise.noise(facet.getWorldArea(), scale);
         float[] rivers = facet.getInternal();
         float noiseMult = 10f / (configuration.riverWidth * configuration.riverDensity);
         for (int i = 0; i < noise.length; ++i) {
             rivers[i] = -Math.min(0, Math.abs(noise[i]) * noiseMult - 1);
+            humidity[i] += Math.max(0, rivers[i] - 0.4) * 0.3;
         }
 
         region.setRegionFacet(RiverFacet.class, facet);


### PR DESCRIPTION
This adds mesas/buttes/plateaus based on noise which is scaled very sharply. They have mostly flat sides and tops, but they vary in height based on another noise which is changes more slowly. The tops have the steppe biome, and strata are visible all along the sides.

A large mesa:
![Terasology-210707151042-1920x1080](https://user-images.githubusercontent.com/13039463/124824078-84414f00-df37-11eb-8824-88aee7f7ea53.png)

Some smaller buttes:
![Terasology-210707151403-1920x1080](https://user-images.githubusercontent.com/13039463/124824293-cbc7db00-df37-11eb-90c8-39553759a9cc.png)

This is what happens when there's a fluctuation in a higher octave at the exact right level, I think it's a nice effect:
![Terasology-210707151416-1920x1080](https://user-images.githubusercontent.com/13039463/124824294-cc607180-df37-11eb-8ec0-3810f704ea1f.png)

Right now rivers going through mesas don't look very good, so I'm still working on the interaction between those.