### PR TITLE
fix: clamp steepness to avoid inverted rivers

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -60,7 +60,7 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
         Biome[] biomeData = biomes.getInternal();
         Iterator<Vector2ic> positions = elevation.getWorldArea().iterator();
         for (int i = 0; i < surfaceHeights.length; ++i) {
-            float steepness = steepnessData[i];
+            float steepness = TeraMath.clamp(steepnessData[i]);
             float riverFac = TeraMath.clamp(riversData[i]);
 
             // The river bed height is calculated as the sum of two curves, one for below the water and one above


### PR DESCRIPTION
Noise with multiple octaves like rivers use can actually go a little bit beyond the [0, 1] range. If the steepness went below 0, it would lead to inverted rivers like this (seed nc4ndFDUGz1gUfXj, x: 70, z: 1400; may or may not be reproducible there). Clamping the steepness to the correct range fixes this artifact.

![Terasology-210712180432-1920x1080](https://user-images.githubusercontent.com/13039463/125367445-c4407180-e33d-11eb-978e-9dd1685c4dd6.png)