### PR TITLE
feat: shallower or completely dry rivers in drier areas

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -70,7 +70,7 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
             float riverBedLow = lowFac * TeraMath.fadePerlin(TeraMath.clamp(narrowness * (riverFac - 1) + 1));
             float riverBedElevation = seaLevel + rivers.maxDepth * (riverBedHigh - riverBedLow);
 
-            float humidityAdj = Math.max(0,  12 * (0.3f - humidityData[i]));
+            float humidityAdj = Math.max(0, 15 * (0.4f - humidityData[i]));
             riverBedElevation += rivers.maxDepth * humidityAdj;
 
             // Never raise the surface to the river bed, erosion only goes downward
@@ -82,7 +82,7 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider {
             }
 
             Vector2ic pos = positions.next();
-            if (TeraMath.clamp(riversData[i]) - 0.1 * humidityAdj > 0.86 + 0.03 * whiteNoiseRiver.noise(pos.x(), pos.y())) {
+            if (TeraMath.clamp(riversData[i]) - 0.2 * humidityAdj > 0.86 + 0.03 * whiteNoiseRiver.noise(pos.x(), pos.y())) {
                 biomeData[i] = MRBiome.RIVER;
             }
         }


### PR DESCRIPTION
This raises the riverbed by up to `maxDepth` blocks in dry areas, so that the river is shallower and sometimes doesn't have water at all. It still needs some tweaks, especially to the river biome allocation, and to make sure that it doesn't mess with other rivers too much; I'd also like canyons without water to be more common, but I'm not sure how feasible that actually is.

![Terasology-210729145154-1536x864](https://user-images.githubusercontent.com/13039463/127557889-4e134128-0e61-4e03-a097-e7e69786cebf.png)
