### PR TITLE
feat: block tinting support for MR biomes and dry grass in scrublands

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
@@ -83,12 +83,42 @@ public enum MRBiome implements Biome {
     }
 
     @Override
+    public float getHumidity() {
+        switch (this) {
+            case ROCKY:
+                return 0.4f;
+            case SCRUBLAND:
+                return 0.2f;
+            case STEPPE:
+                return 0.6f;
+            case RIVER:
+                return 0.8f;
+        }
+        return 0.5f;
+    }
+
+    @Override
+    public float getTemperature() {
+        switch (this) {
+            case ROCKY:
+                return 0.5f;
+            case SCRUBLAND:
+                return 0.8f;
+            case STEPPE:
+                return 0.4f;
+            case RIVER:
+                return 0.5f;
+        }
+        return 0.5f;
+    }
+
+    @Override
     public Block getSurfaceBlock(Vector3ic pos, int seaLevel) {
         switch (this) {
             case ROCKY:
                 return getStratum(pos);
             case SCRUBLAND:
-                return dirt;
+                return grass;
             case RIVER:
                 if (pos.y() < seaLevel) {
                     // Don't put grass under water

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/MRBiome.java
@@ -88,7 +88,7 @@ public enum MRBiome implements Biome {
             case ROCKY:
                 return 0.4f;
             case SCRUBLAND:
-                return 0.2f;
+                return 0;
             case STEPPE:
                 return 0.6f;
             case RIVER:
@@ -103,7 +103,7 @@ public enum MRBiome implements Biome {
             case ROCKY:
                 return 0.5f;
             case SCRUBLAND:
-                return 0.8f;
+                return 1;
             case STEPPE:
                 return 0.4f;
             case RIVER:


### PR DESCRIPTION
Now that block tinting is supported, this PR uses it for dry grass in scrublands instead of dirt.
![Terasology-210730155050-1920x1080](https://user-images.githubusercontent.com/13039463/127710791-7fd34e23-c340-4a0c-b526-2894660b6b1b.png)
![Terasology-210730153236-1920x1080](https://user-images.githubusercontent.com/13039463/127710829-2adca165-dfac-4436-afef-3295f1aca0e0.png)

I'm not sure if it's quite dramatic enough, but I don't think it's possible to get much more without changing the tinting lookup tables in the engine.