### PR TITLE
feat: add explicit facet provider priority

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
@@ -15,6 +15,7 @@ import org.terasology.engine.world.generation.ConfigurableFacetProvider;
 import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.UpdatePriority;
 import org.terasology.engine.world.generation.Updates;
 import org.terasology.engine.world.generation.facets.ElevationFacet;
 import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
@@ -34,7 +35,7 @@ import java.util.Iterator;
  * It also sets the biome to the rocky biome on mountains.
  */
 @Requires(@Facet(SurfaceHumidityFacet.class))
-@Updates({@Facet(ElevationFacet.class), @Facet(BiomeFacet.class)})
+@Updates(value = {@Facet(ElevationFacet.class), @Facet(BiomeFacet.class)}, priority = UpdatePriority.PRIORITY_NORMAL)
 public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvider {
 
     private SubSampledNoise mountainNoise;

--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/BaseBiomeProvider.java
@@ -13,10 +13,9 @@ import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.FacetProvider;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
-import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.UpdatePriority;
 import org.terasology.engine.world.generation.Updates;
 import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
-import org.terasology.metalrenegades.world.rivers.RiverFacet;
 
 import java.util.Iterator;
 
@@ -26,7 +25,7 @@ import java.util.Iterator;
  * Providers for features like rivers and mountains will adjust it further.
  */
 @Produces(BiomeFacet.class)
-@Requires(@Facet(SurfaceHumidityFacet.class))
+@Updates(value = @Facet(SurfaceHumidityFacet.class), priority = UpdatePriority.PRIORITY_CRITICAL)
 public class BaseBiomeProvider implements FacetProvider {
 
     private WhiteNoise whiteNoise;

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
@@ -13,12 +13,13 @@ import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
 import org.terasology.engine.world.generation.ScalableFacetProvider;
+import org.terasology.engine.world.generation.UpdatePriority;
 import org.terasology.engine.world.generation.Updates;
 import org.terasology.engine.world.generation.facets.SurfaceHumidityFacet;
 import org.terasology.nui.properties.Range;
 
 @Produces(RiverFacet.class)
-@Updates(@Facet(SurfaceHumidityFacet.class))
+@Updates(value = @Facet(SurfaceHumidityFacet.class), priority = UpdatePriority.PRIORITY_HIGH)
 public class RiverProvider implements ScalableFacetProvider, ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -16,6 +16,7 @@ import org.terasology.engine.world.generation.ConfigurableFacetProvider;
 import org.terasology.engine.world.generation.Facet;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Requires;
+import org.terasology.engine.world.generation.UpdatePriority;
 import org.terasology.engine.world.generation.Updates;
 import org.terasology.engine.world.generation.facets.ElevationFacet;
 import org.terasology.engine.world.generation.facets.SeaLevelFacet;
@@ -27,7 +28,7 @@ import java.util.Iterator;
 
 
 @Requires({@Facet(RiverFacet.class), @Facet(SeaLevelFacet.class), @Facet(SurfaceHumidityFacet.class)})
-@Updates({@Facet(ElevationFacet.class), @Facet(BiomeFacet.class)})
+@Updates(value = {@Facet(ElevationFacet.class), @Facet(BiomeFacet.class)}, priority = UpdatePriority.PRIORITY_LOW)
 public class RiverToElevationProvider implements ConfigurableFacetProvider {
     private static final int SAMPLE_RATE = 4;
 


### PR DESCRIPTION
Now that facet provider ordering can be made explicit, this PR enforces the ordering `BaseBiomeProvider -> RiverProvider -> SimplexHillsAndMountainsProvider -> RiverToElevationProvider`. This also fixes a bug where scrublands would always generate around rivers because the river increases the humidity; now that rivers aren't generated until after the base biomes, this doesn't happen.