### PR TITLE
feat: tweak distribution of grass and dry rivers

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/dynamic/FloraProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/dynamic/FloraProvider.java
@@ -69,6 +69,7 @@ public class FloraProvider extends SurfaceObjectProvider<Biome, FloraType> imple
         }
 
         register(CoreBiome.DESERT, FloraType.MUSHROOM, 0);
+        register(MRBiome.SCRUBLAND, FloraType.GRASS, 0.2f);
     }
 
     @Override

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -72,7 +72,7 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider, Scal
             float riverBedLow = lowFac * TeraMath.fadePerlin(TeraMath.clamp(narrowness * (riverFac - 1) + 1));
             float riverBedElevation = seaLevel + rivers.maxDepth * (riverBedHigh - riverBedLow);
 
-            float humidityAdj = Math.max(0, 15 * (0.4f - humidityData[i]));
+            float humidityAdj = Math.max(0, 15 * (0.35f - humidityData[i]));
             riverBedElevation += rivers.maxDepth * humidityAdj;
 
             // Never raise the surface to the river bed, erosion only goes downward


### PR DESCRIPTION
This makes grass much more common in scrublands, and makes dry riverbeds slightly less common. It should make the world look a little better in general.