### PR TITLE
fix: correctly reference MeshAnimations in enemyGooey.prefab

### DIFF
--- a/assets/prefabs/characters/enemyGooey.prefab
+++ b/assets/prefabs/characters/enemyGooey.prefab
@@ -14,22 +14,22 @@
   },
   "Stand": {
     "animationPool": [
-      "Gooey:mawgooeyIdleFinal"
+      "Gooey:mawgooey#IdleFinal"
     ]
   },
   "Walk": {
     "animationPool": [
-      "Gooey:mawgooeyWalk"
+      "Gooey:mawgooey#Walk"
     ]
   },
   "MeleeAttack": {
     "animationPool": [
-      "Gooey:mawgooeyAttack"
+      "Gooey:mawgooey#Attack"
     ]
   },
   "Die": {
     "animationPool": [
-      "Gooey:mawgooeyDeath"
+      "Gooey:mawgooey#Death"
     ]
   },
   "persisted": true,


### PR DESCRIPTION
Due to the missing `#` the mesh animations were not correctly
referenced, and the animation pool stayed empty. This lead to the
following warning being printed because we try to randomly select an
element from the empty list:

```
22:16:58.081 [main] INFO  o.t.e.logic.behavior.core.ActionNode - Exception while running construct() of action org.terasology.behaviors.actions.SetAnimationAction@5a36810a from entity EntityRef{id = 11478, netId = 0, prefab = 'MetalRenegades:enemyGooey'}: bound must be positive
```

With at least one animation in the pool this issue is fixed.
