### PR TITLE
chore: reduce max number of enemies

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/combat/system/EnemySpawnSystem.java
+++ b/src/main/java/org/terasology/metalrenegades/combat/system/EnemySpawnSystem.java
@@ -87,7 +87,7 @@ public class EnemySpawnSystem extends BaseComponentSystem implements UpdateSubsc
     /**
      * The maximum number of enemies that can spawn in the world.
      */
-    private static final int MAX_ENEMIES = 30;
+    private static final int MAX_ENEMIES = 15;
 
     /**
      * True if this system is initialised, false otherwise.


### PR DESCRIPTION
**Problem:** There are too many enemy Gooeys spawning at night.

**Solution:** Reduce the number of maximum enemys from 30 to 15. 

Observe the new value in future play-tests and potentially adjust it further.