### PR TITLE
refactor: Adjust for Behaviors#89

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/ai/actions/SetTargetToHomeAction.java
+++ b/src/main/java/org/terasology/metalrenegades/ai/actions/SetTargetToHomeAction.java
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.metalrenegades.ai.actions;
 
+import org.joml.RoundingMode;
 import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
@@ -24,11 +26,9 @@ public class SetTargetToHomeAction extends BaseAction {
 
         Vector3f position = homeLocationComponent.getWorldPosition(new Vector3f());
 
-        if (position != null) {
-            MinionMoveComponent minionMoveComponent = actor.getComponent(MinionMoveComponent.class);
-            minionMoveComponent.target = position;
-            actor.save(minionMoveComponent);
-        }
+        MinionMoveComponent minionMoveComponent = actor.getComponent(MinionMoveComponent.class);
+        minionMoveComponent.target = new Vector3i(position, RoundingMode.FLOOR);
+        actor.save(minionMoveComponent);
 
         return BehaviorState.SUCCESS;
     }


### PR DESCRIPTION
Adjust for https://github.com/Terasology/Behaviors/pull/89

A few components and systems have changed due to the switch from Pathfinding to FlexiblePathfinding.

This PR adjusts the breaking pieces of code to the best of my knowledge. Typical changes for this migration are:

- `MinionMoveComponent#target` is now a `Vector3i` and no longer a `Vector3f` (fixed by rounding)
- `MinionMoveComponent#type` was removed (no longer required, just remove references)
