### PR TITLE
chore: consume tooltip icon from `Gooey` module

### DIFF
--- a/assets/prefabs/characters/enemyGooey.prefab
+++ b/assets/prefabs/characters/enemyGooey.prefab
@@ -38,7 +38,7 @@
   "AliveCharacter": {},
   "WildAnimal": {
     "name": "MawGooey",
-    "icon": "WildAnimals:icons#mawGooey"
+    "icon": "Gooey:MawGooeyGreenTooltip"
   },
   "NPCMovement": {},
   "CreatureNameGenerator": {


### PR DESCRIPTION
Depends on https://github.com/Terasology/Gooey/pull/14