### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/SimplexHillsAndMountainsProvider.java
@@ -135,7 +135,7 @@ public class SimplexHillsAndMountainsProvider implements ConfigurableFacetProvid
         this.configuration = (SimplexHillsAndMountainsProviderConfiguration) configuration;
     }
 
-    private static class SimplexHillsAndMountainsProviderConfiguration implements Component<SimplexHillsAndMountainsProviderConfiguration> {
+    public static class SimplexHillsAndMountainsProviderConfiguration implements Component<SimplexHillsAndMountainsProviderConfiguration> {
 
         @Range(min = 0, max = 3f, increment = 0.01f, precision = 2, description = "Mountain Amplitude")
         public float mountainAmplitude = 1f;

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverProvider.java
@@ -70,7 +70,7 @@ public class RiverProvider implements ScalableFacetProvider, ConfigurableFacetPr
         setSeed(seed);
     }
 
-    private static class Configuration implements Component<Configuration> {
+    public static class Configuration implements Component<Configuration> {
         @Range(label = "River width", min = 1, max = 64f, increment = 1f, precision = 0, description = "Average river width (approximate)")
         public float riverWidth = 10;
 

--- a/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
+++ b/src/main/java/org/terasology/metalrenegades/world/rivers/RiverToElevationProvider.java
@@ -105,7 +105,7 @@ public class RiverToElevationProvider implements ConfigurableFacetProvider, Scal
         this.configuration = (Configuration) configuration;
     }
 
-    private static class Configuration implements Component<Configuration> {
+    public static class Configuration implements Component<Configuration> {
         @Override
         public void copyFrom(Configuration other) {
 


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191